### PR TITLE
Remove trailing 'piraeus' from etcdendpoint

### DIFF
--- a/deploy.template/funcs.lib.yml
+++ b/deploy.template/funcs.lib.yml
@@ -9,7 +9,7 @@
 #@ end
 
 #@ def etcdendpoint():
-#@   return "http://" + etcd() + name() + ":2379"
+#@   return "http://" + etcd() + ":2379"
 #@ end
 
 #@ def node():

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -58,7 +58,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ETCDCTL_ENDPOINTS
-          value: http://piraeus-etcdpiraeus:2379
+          value: http://piraeus-etcd:2379
         - name: ETCDCTL_API
           value: "3"
         - name: ETCD_CLUSTER_SIZE


### PR DESCRIPTION
Fixes the following error:
Error while dialing dial tcp: lookup piraeus-etcdpiraeus on 10.96.0.10:53: no such host