### PR TITLE
Switch to using kube-system namespace

### DIFF
--- a/deploy.template/controller.yaml
+++ b/deploy.template/controller.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: #@ controller()
-  namespace: #@ name()
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ controller()
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: #@ controller()
-  namespace: #@ name()
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ controller()

--- a/deploy.template/csi.yaml
+++ b/deploy.template/csi.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: #@ csicontroller()
-  namespace: #@ name()
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ csicontroller()
@@ -169,7 +169,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: #@ csicontroller() + "-sa"
-  namespace: #@ name()
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -205,7 +205,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: #@ csicontroller() + "-sa"
-    namespace: #@ name()
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-provisioner-role
@@ -236,7 +236,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: #@ csicontroller() + "-sa"
-    namespace: #@ name()
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-attacher-role
@@ -261,7 +261,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: #@ csicontroller() + "-sa"
-    namespace: #@ name()
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-cluster-driver-registrar-role
@@ -271,7 +271,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: #@ csinode()
-  namespace: #@ name()
+  namespace: kube-system
 spec:
   minReadySeconds: 0
   updateStrategy:
@@ -403,13 +403,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: #@ csinode() + "-sa"
-  namespace: #@ name()
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-driver-registrar-role
-  namespace: #@ name()
+  namespace: kube-system
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -422,7 +422,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: #@ csinode() + "-sa"
-  namespace: #@ name()
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-driver-registrar-role
@@ -468,7 +468,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: #@ controller() + "-sa"
-  namespace: #@ name()
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-snapshotter-role

--- a/deploy.template/etcd.yaml
+++ b/deploy.template/etcd.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: #@ etcd()
-  namespace: #@ name()
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ etcd()
@@ -34,7 +34,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: #@ etcd()
-  namespace: #@ name()
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ etcd()

--- a/deploy.template/funcs.lib.yml
+++ b/deploy.template/funcs.lib.yml
@@ -29,7 +29,7 @@
 #@ end
 
 #@ def controllerhostport():
-#@   return name() + "-controller." + name() + ":3370"
+#@   return name() + "-controller.kube-system" + ":3370"
 #@ end
 
 #@ def registry():

--- a/deploy.template/node.yaml
+++ b/deploy.template/node.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: #@ node()
-  namespace: #@ name()
+  namespace: kube-system
 spec:
   minReadySeconds: 0
   updateStrategy:

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: piraeus-controller
-  namespace: piraeus
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-controller
@@ -20,7 +20,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: piraeus-controller
-  namespace: piraeus
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-controller

--- a/deploy/csi.yaml
+++ b/deploy/csi.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: piraeus-csi-controller
-  namespace: piraeus
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-csi-controller
@@ -116,7 +116,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LS_CONTROLLERS
-          value: http://piraeus-controller.piraeus:3370
+          value: http://piraeus-controller.kube-system:3370
         volumeMounts:
         - name: localtime
           mountPath: /etc/localtime
@@ -133,7 +133,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: piraeus-csi-controller-sa
-  namespace: piraeus
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -206,7 +206,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: piraeus-csi-controller-sa
-  namespace: piraeus
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-provisioner-role
@@ -259,7 +259,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: piraeus-csi-controller-sa
-  namespace: piraeus
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-attacher-role
@@ -293,7 +293,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: piraeus-csi-controller-sa
-  namespace: piraeus
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-cluster-driver-registrar-role
@@ -303,7 +303,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: piraeus-csi-node
-  namespace: piraeus
+  namespace: kube-system
 spec:
   minReadySeconds: 0
   updateStrategy:
@@ -375,7 +375,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LS_CONTROLLERS
-          value: http://piraeus-controller.piraeus:3370
+          value: http://piraeus-controller.kube-system:3370
         securityContext:
           privileged: true
           capabilities:
@@ -428,13 +428,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: piraeus-csi-node-sa
-  namespace: piraeus
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-driver-registrar-role
-  namespace: piraeus
+  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -455,7 +455,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: piraeus-csi-node-sa
-  namespace: piraeus
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-driver-registrar-role
@@ -552,7 +552,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: piraeus-controller-sa
-  namespace: piraeus
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-snapshotter-role

--- a/deploy/etcd.yaml
+++ b/deploy/etcd.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: piraeus-etcd
-  namespace: piraeus
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-etcd
@@ -30,7 +30,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: piraeus-etcd
-  namespace: piraeus
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-etcd

--- a/deploy/node.yaml
+++ b/deploy/node.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: piraeus-node
-  namespace: piraeus
+  namespace: kube-system
 spec:
   minReadySeconds: 0
   updateStrategy:
@@ -48,7 +48,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LS_CONTROLLERS
-          value: piraeus-controller.piraeus:3370
+          value: piraeus-controller.kube-system:3370
         - name: TIMEOUT
           value: "3600"
         - name: REGISTRY
@@ -84,7 +84,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LS_CONTROLLERS
-          value: piraeus-controller.piraeus:3370
+          value: piraeus-controller.kube-system:3370
         - name: DemoPool_Dir
           value: /var/local/piraeus/pools/DemoPool
         args:


### PR DESCRIPTION
Due to https://github.com/kubernetes/kubernetes/issues/60596, we cannot
use 'priorityClass: system-node-critical' with Kubernetes versions prior
to 1.17.