### PR TITLE
Make mapping of host LVM directories optional

### DIFF
--- a/deploy.template/config.yml
+++ b/deploy.template/config.yml
@@ -2,6 +2,7 @@
 ---
 name: "piraeus"
 map_host_linstor: false
+map_host_lvm: false
 registry: "quay.io/piraeusdatastore"
 initversion: "v0.1"
 contsatversion: "v1.3.1"

--- a/deploy.template/funcs.lib.yml
+++ b/deploy.template/funcs.lib.yml
@@ -8,6 +8,10 @@
 #@   return data.values.map_host_linstor
 #@ end
 
+#@ def map_host_lvm():
+#@   return data.values.map_host_lvm
+#@ end
+
 #@ def etcd():
 #@   return name() + "-etcd"
 #@ end

--- a/deploy.template/node.yaml
+++ b/deploy.template/node.yaml
@@ -1,4 +1,4 @@
-#@ load("funcs.lib.yml", "map_host_linstor", "name", "node", "initimage", "controllerhostport", "registry", "controllerimage", "satelliteimage")
+#@ load("funcs.lib.yml", "map_host_linstor", "map_host_lvm", "name", "node", "initimage", "controllerhostport", "registry", "controllerimage", "satelliteimage")
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -126,10 +126,12 @@ spec:
               mountPath: /dev
             - name: lib-modules
               mountPath: /lib/modules
+            #@ if map_host_lvm():
             - name: etc-lvm
               mountPath: /etc/lvm
             - name: run-lvm
               mountPath: /run/lvm
+            #@ end
             #@ if map_host_linstor():
             - name: etc-drbd-d
               mountPath: /etc/drbd.d
@@ -166,12 +168,14 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        #@ if map_host_lvm():
         - name: etc-lvm
           hostPath:
             path: /etc/lvm
         - name: run-lvm
           hostPath:
             path: /run/lvm
+        #@ end
         #@ if map_host_linstor():
         - name: etc-drbd-d
           hostPath:

--- a/deploy/node.yaml
+++ b/deploy/node.yaml
@@ -114,10 +114,6 @@ spec:
           mountPath: /dev
         - name: lib-modules
           mountPath: /lib/modules
-        - name: etc-lvm
-          mountPath: /etc/lvm
-        - name: run-lvm
-          mountPath: /run/lvm
       volumes:
       - name: localtime
         hostPath:
@@ -146,12 +142,6 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-      - name: etc-lvm
-        hostPath:
-          path: /etc/lvm
-      - name: run-lvm
-        hostPath:
-          path: /run/lvm
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Alternatively, we could just have one config option that disables the host mapping of linstor and lvm.