### PR TITLE
Fixed deploy.template/40_csi.yaml

### DIFF
--- a/deploy.template/40_csi.yaml
+++ b/deploy.template/40_csi.yaml
@@ -1,6 +1,6 @@
 #@ load("funcs.lib.yml", "name", "csicontroller", "csiimage", "controllerhostport", "csinode", "controller")
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: #@ csicontroller()
@@ -267,7 +267,7 @@ roleRef:
   name: csi-cluster-driver-registrar-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: DaemonSet
 metadata:
   name: #@ csinode()
@@ -278,6 +278,10 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: #@ name()
+      app.kubernetes.io/component: #@ csinode()
   template:
     metadata:
       labels:

--- a/deploy/40_csi.yaml
+++ b/deploy/40_csi.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: piraeus-csi-controller
@@ -299,7 +299,7 @@ roleRef:
   name: csi-cluster-driver-registrar-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: DaemonSet
 metadata:
   name: piraeus-csi-node
@@ -310,6 +310,10 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-node
   template:
     metadata:
       labels:

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -424,7 +424,7 @@ spec:
       - operator: Exists
         effect: NoSchedule
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: piraeus-csi-controller
@@ -725,7 +725,7 @@ roleRef:
   name: csi-cluster-driver-registrar-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: DaemonSet
 metadata:
   name: piraeus-csi-node
@@ -736,6 +736,10 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-node
   template:
     metadata:
       labels:


### PR DESCRIPTION
So that deploy yml files are compatible with k8s 1.16+ version: 
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals
Run make all afterwards.