### PR TITLE
Fixed deployment error by correcting YAML syntax

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -464,7 +464,180 @@ spec:
       - operator: Exists
         effect: NoSchedule
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-node
+  namespace: kube-system
+data:
+  INIT_DEBUG: "false"
+  MIN_WAIT: "5"
+  MAX_WAIT: "3600"
+  LS_CONTROLLERS: http://piraeus-controller.kube-system:3370
+  DRBD_IMG_REPO: quay.io/piraeusdatastore
+  DRBD_IMG_TAG: v9.0.21
+  DRBD_IMG_PULL_POLICY: Always
+  POOL_BASE_DIR: /var/local/piraeus/storagepools
 ---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-node
+  namespace: kube-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-node
+    spec:
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: THIS_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: THIS_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: THIS_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: localtime
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+      containers:
+      - name: node
+        image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: THIS_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: THIS_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - startSatellite
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /init/cmd/poststart-node.sh
+        readinessProbe:
+          successThreshold: 3
+          failureThreshold: 3
+          tcpSocket:
+            port: 3366
+          initialDelaySeconds: 5
+          periodSeconds: 1
+        volumeMounts:
+        - name: localtime
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: log
+          mountPath: /var/log/linstor-satellite
+        - name: var-local-piraeus
+          mountPath: /var/local/piraeus
+        - name: dev
+          mountPath: /dev
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: run-lvm
+          mountPath: /run/lvm
+      volumes:
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: init
+        emptyDir: {}
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-satellite
+      - name: var-local-piraeus
+        hostPath:
+          path: /var/local/piraeus
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: usr-sbin
+        hostPath:
+          path: /usr/sbin
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: run-lvm
+        hostPath:
+          path: /run/lvm
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -640,180 +813,7 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: piraeus-node
-  namespace: kube-system
-data:
-  INIT_DEBUG: "false"
-  MIN_WAIT: "5"
-  MAX_WAIT: "3600"
-  LS_CONTROLLERS: http://piraeus-controller.kube-system:3370
-  DRBD_IMG_REPO: quay.io/piraeusdatastore
-  DRBD_IMG_TAG: v9.0.21
-  DRBD_IMG_PULL_POLICY: Always
-  POOL_BASE_DIR: /var/local/piraeus/storagepools
 ---
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: piraeus-node
-  namespace: kube-system
-spec:
-  minReadySeconds: 0
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: piraeus
-      app.kubernetes.io/component: piraeus-node
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: piraeus
-        app.kubernetes.io/component: piraeus-node
-    spec:
-      priorityClassName: system-node-critical
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 0
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      initContainers:
-      - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5
-        imagePullPolicy: Always
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-        envFrom:
-        - configMapRef:
-            name: piraeus-node
-        env:
-        - name: THIS_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: THIS_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: THIS_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: localtime
-          mountPath: /etc/localtime
-        - name: init
-          mountPath: /init
-        - name: dockersock
-          mountPath: /var/run/docker.sock
-        - name: usr-src
-          mountPath: /usr/src
-        - name: lib-modules
-          mountPath: /lib/modules
-      containers:
-      - name: node
-        image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
-        imagePullPolicy: Always
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 1
-            memory: 1Gi
-        envFrom:
-        - configMapRef:
-            name: piraeus-node
-        env:
-        - name: THIS_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: THIS_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        args:
-        - startSatellite
-        lifecycle:
-          postStart:
-            exec:
-              command:
-              - /init/cmd/poststart-node.sh
-        readinessProbe:
-          successThreshold: 3
-          failureThreshold: 3
-          tcpSocket:
-            port: 3366
-          initialDelaySeconds: 5
-          periodSeconds: 1
-        volumeMounts:
-        - name: localtime
-          mountPath: /etc/localtime
-        - name: init
-          mountPath: /init
-        - name: log
-          mountPath: /var/log/linstor-satellite
-        - name: var-local-piraeus
-          mountPath: /var/local/piraeus
-        - name: dev
-          mountPath: /dev
-        - name: lib-modules
-          mountPath: /lib/modules
-        - name: run-lvm
-          mountPath: /run/lvm
-      volumes:
-      - name: localtime
-        hostPath:
-          path: /etc/localtime
-      - name: init
-        emptyDir: {}
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
-          type: Socket
-      - name: log
-        hostPath:
-          path: /var/log/piraeus/linstor-satellite
-      - name: var-local-piraeus
-        hostPath:
-          path: /var/local/piraeus
-      - name: dev
-        hostPath:
-          path: /dev
-      - name: usr-sbin
-        hostPath:
-          path: /usr/sbin
-      - name: usr-src
-        hostPath:
-          path: /usr/src
-      - name: lib-modules
-        hostPath:
-          path: /lib/modules
-      - name: run-lvm
-        hostPath:
-          path: /run/lvm
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: piraeus/node
-                operator: In
-                values:
-                - "true"
-              - key: node-role.kubernetes.io/master
-                operator: DoesNotExist
-      tolerations:
-      - operator: Exists
-        effect: NoSchedule
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1611,6 +1611,7 @@ parameters:
   disklessOnRemaining: "false"
   mountOpts: noatime,discard
   storagePool: DfltStorPool
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -2231,6 +2232,7 @@ parameters:
   disklessOnRemaining: "false"
   mountOpts: noatime,discard
   storagePool: DfltStorPool
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -2851,3 +2853,4 @@ parameters:
   disklessOnRemaining: "false"
   mountOpts: noatime,discard
   storagePool: DfltStorPool
+


### PR DESCRIPTION
Was unable to deploy the `all.yaml` example due to syntax (orderning) errors.
