### PR TITLE
Explicitly specify drbd-driver-loader image, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The hosts should use Docker as their container runtime and be running one of the
 The nodes on which piraeus should provide or consume storage should be labelled as follows:
 
 ```
-kubectl label nodes $NODE_NAME piraeus/enabled=true
+kubectl label nodes $NODE_NAME piraeus/node=true
 ```
 
 These nodes must also have the appropriate kernel development package installed unless DRBD is already present.

--- a/demo/demo-pvc.yaml
+++ b/demo/demo-pvc.yaml
@@ -39,3 +39,17 @@ spec:
   resources:
     requests:
       storage: 13Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: demo-rwo-raw
+  namespace: piraeus-demo
+spec:
+  storageClassName: piraeus-dflt-raw
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Gi

--- a/demo/mysql/create-mysql.sh
+++ b/demo/mysql/create-mysql.sh
@@ -2,11 +2,11 @@
 
 if [[ "$1" == 'cn' ]]; then
     cat demo-sts-mysql.yaml \
-    | sed 's/gcr.io/gcr.azk8s.cn/' \
-    | sed 's/docker.io/dockerhub.azk8s.cn/' \
+    | sed 's#gcr.io/google-samples/#daocloud.io/piraeus/#' \
+    | sed 's#docker.io/library/#daocloud.io/piraeus/#' \
     | kubectl apply -f -
 else 
-    kubectl apply -f demo-mysql.sh
+    kubectl apply -f demo-sts-mysql.sh
 fi
 
 watch kubectl -n piraeus-demo -l app=mysql get po -o wide

--- a/deploy.template/10_etcd.yaml
+++ b/deploy.template/10_etcd.yaml
@@ -1,4 +1,4 @@
-#@ load("funcs.lib.yml", "name", "namespace", "timezone", "etcd", "etcdendpoint", "initimage", "set_priority_class")
+#@ load("funcs.lib.yml", "name", "namespace", "timezone", "etcd", "etcdimage", "etcdendpoint", "initimage", "set_priority_class")
 #! dns service for stable DNS entries of StatefulSet members.
 #! https://kubernetes.io/docs/tasks/run-application/run-replicated-stateful-application/
 ---
@@ -91,7 +91,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:v3.4.5
+        image: #@ etcdimage()
         imagePullPolicy: IfNotPresent
         resources:
           #! requests:

--- a/deploy.template/10_etcd.yaml
+++ b/deploy.template/10_etcd.yaml
@@ -139,9 +139,8 @@ spec:
       - name: init
         emptyDir: {}
       - name: data
-        emptyDir: {}
-        #! hostPath:
-        #!   path: #@ "/var/lib/" + name() + "/etcd"
+        hostPath:
+          path: #@ "/var/lib/" + name() + "/etcd"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy.template/20_controller.yaml
+++ b/deploy.template/20_controller.yaml
@@ -106,13 +106,15 @@ spec:
         #@ if name() == "piraeus":
         args:
         - startController
-        - --stack-traces
+        #! - --stack-traces
+        #! - --log-level
+        #! - TRACE
         #@ end
         readinessProbe:
-          successThreshold: 3
-          failureThreshold: 3
           httpGet:
             port: 3370
+          successThreshold: 3
+          failureThreshold: 3
           periodSeconds: 5
         volumeMounts:
         - name: timezone

--- a/deploy.template/30_node.yaml
+++ b/deploy.template/30_node.yaml
@@ -123,9 +123,9 @@ spec:
         #@ if name() == "piraeus":
         args:
         - startSatellite
-        - --stack-traces
-        - --log-level
-        - TRACE
+        #! - --stack-traces
+        #! - --log-level
+        #! - TRACE
         #@ end
         readinessProbe:
           successThreshold: 3

--- a/deploy.template/30_node.yaml
+++ b/deploy.template/30_node.yaml
@@ -91,6 +91,10 @@ spec:
           mountPath: /lib/modules
         - name: #@ "opt-" + name()
           mountPath: #@ "/opt/" + name()
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
       containers:
       - name: satellite
         image: #@ satelliteimage()
@@ -120,6 +124,8 @@ spec:
         args:
         - startSatellite
         - --stack-traces
+        - --log-level
+        - TRACE
         #@ end
         readinessProbe:
           successThreshold: 3
@@ -139,6 +145,8 @@ spec:
           mountPath: /var/log/linstor-satellite
         - name: #@ "var-lib-" + name()
           mountPath: #@ "/var/lib/" + name()
+        #! - name: default-storage-pool
+        #!   mountPath: /DfltStorPool
         - name: dev
           mountPath: /dev
         - name: lib-modules
@@ -165,6 +173,9 @@ spec:
       - name: #@ "var-lib-" + name()
         hostPath:
           path: #@ "/var/lib/" + name()
+      #! - name: default-storage-pool
+      #!   hostPath:
+      #!     path: /DfltStorPool
       - name: log
         hostPath:
           path: #@ "/var/log/"+ name() + "/linstor-satellite"
@@ -181,6 +192,13 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
       #@ if map_host_lvm():
       - name: run-lvm
         hostPath:           
@@ -190,9 +208,6 @@ spec:
           path: /run/udev 
       #@ end
       #@ if map_host_linstor():
-      - name: etc-drbd-d
-        hostPath:
-          path: /etc/drbd.d
       - name: var-lib-linstor-d
         hostPath:
           path: /var/lib/linstor.d

--- a/deploy.template/30_node.yaml
+++ b/deploy.template/30_node.yaml
@@ -90,8 +90,6 @@ spec:
           mountPath: /lib/modules
         - name: #@ "opt-" + name()
           mountPath: #@ "/opt/" + name()
-        - name: usr-local-bin
-          mountPath: /usr/local/bin
       containers:
       - name: satellite
         image: #@ satelliteimage()
@@ -172,9 +170,6 @@ spec:
       - name: dev
         hostPath:
           path: /dev
-      - name: usr-local-bin
-        hostPath:
-          path: /usr/local/bin
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock

--- a/deploy.template/30_node.yaml
+++ b/deploy.template/30_node.yaml
@@ -9,7 +9,8 @@ data:
   #! Must be an FQDN here, otherwise it might not resolve!
   LS_CONTROLLERS: #@ controllerhostport()
   POOL_BASE_DIR: #@ "/var/lib/" + name() + "/storagepools"
-  DRBD_IMG_TAG: v9.0.21 #! "none" will skip drbd installation
+  DRBD_IMG_REPO: quay.io/piraeusdatastore
+  DRBD_IMG_TAG: v9.0.22 #! "none" will skip drbd installation
   DRBD_IMG_PULL_POLICY: IfNotPresent
   MAP_HOST_LVM: 'true'
 ---

--- a/deploy.template/31_scaler.yaml
+++ b/deploy.template/31_scaler.yaml
@@ -150,14 +150,6 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-      #@ if map_host_lvm():
-      - name: proc 
-        hostPath: 
-          path: /proc
-      - name: run
-        hostPath:            
-          path: /run
-      #@ end
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy.template/Makefile
+++ b/deploy.template/Makefile
@@ -5,12 +5,11 @@ LAST=$(lastword $(DST))
 
 all: ../deploy/$(PREFIX)all.yaml cn dce
 
-# for Chinese users, switch registries to azure local mirror, and tz to shanghai
+# for Chinese users, switch registries to daocloud registry, and tz to shanghai
 cn:
 	cat ../deploy/all.yaml \
-	| sed 's/image: quay.io/image: quay.azk8s.cn/g' \
-	| sed 's/image: docker.io/image: dockerhub.azk8s.cn/g' \
-	| sed 's/image: gcr.io/image: gcr.azk8s.cn/g' \
+	| sed 's#quay.io/piraeusdatastore#daocloud.io/piraeus#g' \
+	| sed 's#quay.io/.*/#daocloud.io/piraeus/#g' \
 	| sed 's#/usr/share/zoneinfo/Etc/UTC#/usr/share/zoneinfo/Asia/Shanghai#g' \
 	> ../deploy/all.cn.yaml
 

--- a/deploy.template/config.yml
+++ b/deploy.template/config.yml
@@ -7,10 +7,10 @@ map_host_linstor: false
 map_host_lvm: false
 set_priority_class: false
 registry: "quay.io/piraeusdatastore"
-initversion: "v0.5.3"
+initversion: "v0.5.4"
 contsatversion: "v1.4.2"
 csiversion: "v0.7.4"
-clientversion: "v1.0.11"
+clientversion: "latest"
 images:
   init: "piraeus-init"
   controller: "piraeus-server"

--- a/deploy.template/config.yml
+++ b/deploy.template/config.yml
@@ -7,7 +7,8 @@ map_host_linstor: true
 map_host_lvm: false
 set_priority_class: false
 registry: "quay.io/piraeusdatastore"
-initversion: "v0.5.4"
+etcdversion: "v3.4.7"
+initversion: "v0.5.5"
 contsatversion: "v1.4.2"
 csiversion: "v0.7.4"
 clientversion: "latest"

--- a/deploy.template/config.yml
+++ b/deploy.template/config.yml
@@ -3,7 +3,7 @@
 name: "piraeus"
 namespace: "piraeus-system"
 timezone: "/usr/share/zoneinfo/Etc/UTC"
-map_host_linstor: false
+map_host_linstor: true
 map_host_lvm: false
 set_priority_class: false
 registry: "quay.io/piraeusdatastore"

--- a/deploy.template/funcs.lib.yml
+++ b/deploy.template/funcs.lib.yml
@@ -24,6 +24,10 @@
 #@   return name() + "-etcd"
 #@ end
 
+#@ def etcdimage():
+#@   return "quay.io/coreos/etcd:" + data.values.etcdversion
+#@ end
+
 #@ def etcdendpoint():
 #@   return name() + "-etcd." + namespace() + ".svc.cluster.local:2379"
 #@ end

--- a/deploy/10_etcd.yaml
+++ b/deploy/10_etcd.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: Always
         resources:
           limits:
@@ -125,7 +125,8 @@ spec:
       - name: init
         emptyDir: {}
       - name: data
-        emptyDir: {}
+        hostPath:
+          path: /var/lib/piraeus/etcd
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/10_etcd.yaml
+++ b/deploy/10_etcd.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: Always
         resources:
           limits:
@@ -79,7 +79,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:v3.4.5
+        image: quay.io/coreos/etcd:v3.4.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/20_controller.yaml
+++ b/deploy/20_controller.yaml
@@ -54,7 +54,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -95,12 +95,11 @@ spec:
               fieldPath: status.podIP
         args:
         - startController
-        - --stack-traces
         readinessProbe:
-          successThreshold: 3
-          failureThreshold: 3
           httpGet:
             port: 3370
+          successThreshold: 3
+          failureThreshold: 3
           periodSeconds: 5
         volumeMounts:
         - name: timezone

--- a/deploy/20_controller.yaml
+++ b/deploy/20_controller.yaml
@@ -54,7 +54,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/30_node.yaml
+++ b/deploy/30_node.yaml
@@ -7,7 +7,8 @@ data:
   INIT_DEBUG: "false"
   LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
   POOL_BASE_DIR: /var/lib/piraeus/storagepools
-  DRBD_IMG_TAG: v9.0.21
+  DRBD_IMG_REPO: quay.io/piraeusdatastore
+  DRBD_IMG_TAG: v9.0.22
   DRBD_IMG_PULL_POLICY: IfNotPresent
   MAP_HOST_LVM: "true"
 ---

--- a/deploy/30_node.yaml
+++ b/deploy/30_node.yaml
@@ -83,6 +83,10 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
       containers:
       - name: satellite
         image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
@@ -108,6 +112,8 @@ spec:
         args:
         - startSatellite
         - --stack-traces
+        - --log-level
+        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -130,6 +136,8 @@ spec:
           mountPath: /dev
         - name: lib-modules
           mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
       volumes:
       - name: timezone
         hostPath:
@@ -158,6 +166,19 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/30_node.yaml
+++ b/deploy/30_node.yaml
@@ -39,7 +39,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -82,8 +82,6 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
-        - name: usr-local-bin
-          mountPath: /usr/local/bin
       containers:
       - name: satellite
         image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
@@ -149,9 +147,6 @@ spec:
       - name: dev
         hostPath:
           path: /dev
-      - name: usr-local-bin
-        hostPath:
-          path: /usr/local/bin
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock

--- a/deploy/30_node.yaml
+++ b/deploy/30_node.yaml
@@ -40,7 +40,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -111,9 +111,6 @@ spec:
               fieldPath: spec.nodeName
         args:
         - startSatellite
-        - --stack-traces
-        - --log-level
-        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3

--- a/deploy/31_scaler.yaml
+++ b/deploy/31_scaler.yaml
@@ -44,7 +44,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -67,7 +67,7 @@ spec:
           mountPath: /init
       containers:
       - name: scaler
-        image: quay.io/piraeusdatastore/piraeus-client:v1.0.11
+        image: quay.io/piraeusdatastore/piraeus-client:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/deploy/31_scaler.yaml
+++ b/deploy/31_scaler.yaml
@@ -44,7 +44,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/all.cn.yaml
+++ b/deploy/all.cn.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: Always
         resources:
           limits:
@@ -94,7 +94,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: quay.azk8s.cn/coreos/etcd:v3.4.5
+        image: daocloud.io/piraeus/etcd:v3.4.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -220,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -238,7 +238,7 @@ spec:
           mountPath: /init
       containers:
       - name: controller
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-server:v1.4.2
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -307,7 +307,8 @@ data:
   INIT_DEBUG: "false"
   LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
   POOL_BASE_DIR: /var/lib/piraeus/storagepools
-  DRBD_IMG_TAG: v9.0.21
+  DRBD_IMG_REPO: daocloud.io/piraeus
+  DRBD_IMG_TAG: v9.0.22
   DRBD_IMG_PULL_POLICY: IfNotPresent
   MAP_HOST_LVM: "true"
 ---
@@ -339,7 +340,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -384,7 +385,7 @@ spec:
           mountPath: /opt/piraeus
       containers:
       - name: satellite
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-server:v1.4.2
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -520,7 +521,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -543,7 +544,7 @@ spec:
           mountPath: /init
       containers:
       - name: scaler
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-client:latest
+        image: daocloud.io/piraeus/piraeus-client:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -674,7 +675,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: csi-provisioner
-        image: quay.azk8s.cn/k8scsi/csi-provisioner:v1.5.0
+        image: daocloud.io/piraeus/csi-provisioner:v1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -696,7 +697,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-attacher
-        image: quay.azk8s.cn/k8scsi/csi-attacher:v2.1.1
+        image: daocloud.io/piraeus/csi-attacher:v2.1.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -716,7 +717,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-snapshotter
-        image: quay.azk8s.cn/k8scsi/csi-snapshotter:v2.0.1
+        image: daocloud.io/piraeus/csi-snapshotter:v2.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -735,7 +736,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-cluster-driver-registrar
-        image: quay.azk8s.cn/k8scsi/csi-cluster-driver-registrar:v1.0.1
+        image: daocloud.io/piraeus/csi-cluster-driver-registrar:v1.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -754,7 +755,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: piraeus-csi-plugin
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-csi:v0.7.4
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1141,7 +1142,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: csi-node-driver-registrar
-        image: quay.azk8s.cn/k8scsi/csi-node-driver-registrar:v1.2.0
+        image: daocloud.io/piraeus/csi-node-driver-registrar:v1.2.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1175,7 +1176,7 @@ spec:
         - name: registration-dir
           mountPath: /registration/
       - name: piraeus-csi-plugin
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-csi:v0.7.4
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/all.cn.yaml
+++ b/deploy/all.cn.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: Always
         resources:
           limits:
@@ -140,7 +140,8 @@ spec:
       - name: init
         emptyDir: {}
       - name: data
-        emptyDir: {}
+        hostPath:
+          path: /var/lib/piraeus/etcd
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -219,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -338,7 +339,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -381,8 +382,6 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
-        - name: usr-local-bin
-          mountPath: /usr/local/bin
       containers:
       - name: satellite
         image: quay.azk8s.cn/piraeusdatastore/piraeus-server:v1.4.2
@@ -448,9 +447,6 @@ spec:
       - name: dev
         hostPath:
           path: /dev
-      - name: usr-local-bin
-        hostPath:
-          path: /usr/local/bin
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock
@@ -524,7 +520,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -547,7 +543,7 @@ spec:
           mountPath: /init
       containers:
       - name: scaler
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-client:v1.0.11
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-client:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/deploy/all.cn.yaml
+++ b/deploy/all.cn.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: Always
         resources:
           limits:
@@ -94,7 +94,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: daocloud.io/piraeus/etcd:v3.4.5
+        image: daocloud.io/piraeus/etcd:v3.4.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -220,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -261,12 +261,11 @@ spec:
               fieldPath: status.podIP
         args:
         - startController
-        - --stack-traces
         readinessProbe:
-          successThreshold: 3
-          failureThreshold: 3
           httpGet:
             port: 3370
+          successThreshold: 3
+          failureThreshold: 3
           periodSeconds: 5
         volumeMounts:
         - name: timezone
@@ -340,7 +339,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -411,9 +410,6 @@ spec:
               fieldPath: spec.nodeName
         args:
         - startSatellite
-        - --stack-traces
-        - --log-level
-        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -542,7 +538,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/all.cn.yaml
+++ b/deploy/all.cn.yaml
@@ -383,6 +383,10 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
       containers:
       - name: satellite
         image: daocloud.io/piraeus/piraeus-server:v1.4.2
@@ -408,6 +412,8 @@ spec:
         args:
         - startSatellite
         - --stack-traces
+        - --log-level
+        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -430,6 +436,8 @@ spec:
           mountPath: /dev
         - name: lib-modules
           mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
       volumes:
       - name: timezone
         hostPath:
@@ -458,6 +466,19 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/all.dce.yaml
+++ b/deploy/all.dce.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: Always
         resources:
           limits:
@@ -94,7 +94,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: quay.azk8s.cn/coreos/etcd:v3.4.5
+        image: daocloud.io/piraeus/etcd:v3.4.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -220,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -238,7 +238,7 @@ spec:
           mountPath: /init
       containers:
       - name: controller
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-server:v1.4.2
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -307,7 +307,8 @@ data:
   INIT_DEBUG: "false"
   LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
   POOL_BASE_DIR: /var/lib/piraeus/storagepools
-  DRBD_IMG_TAG: v9.0.21
+  DRBD_IMG_REPO: daocloud.io/piraeus
+  DRBD_IMG_TAG: v9.0.22
   DRBD_IMG_PULL_POLICY: IfNotPresent
   MAP_HOST_LVM: "true"
 ---
@@ -339,7 +340,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -384,7 +385,7 @@ spec:
           mountPath: /opt/piraeus
       containers:
       - name: satellite
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-server:v1.4.2
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -520,7 +521,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -543,7 +544,7 @@ spec:
           mountPath: /init
       containers:
       - name: scaler
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-client:latest
+        image: daocloud.io/piraeus/piraeus-client:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -674,7 +675,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: csi-provisioner
-        image: quay.azk8s.cn/k8scsi/csi-provisioner:v1.5.0
+        image: daocloud.io/piraeus/csi-provisioner:v1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -696,7 +697,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-attacher
-        image: quay.azk8s.cn/k8scsi/csi-attacher:v2.1.1
+        image: daocloud.io/piraeus/csi-attacher:v2.1.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -716,7 +717,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-snapshotter
-        image: quay.azk8s.cn/k8scsi/csi-snapshotter:v2.0.1
+        image: daocloud.io/piraeus/csi-snapshotter:v2.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -735,7 +736,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-cluster-driver-registrar
-        image: quay.azk8s.cn/k8scsi/csi-cluster-driver-registrar:v1.0.1
+        image: daocloud.io/piraeus/csi-cluster-driver-registrar:v1.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -754,7 +755,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: piraeus-csi-plugin
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-csi:v0.7.4
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1141,7 +1142,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: csi-node-driver-registrar
-        image: quay.azk8s.cn/k8scsi/csi-node-driver-registrar:v1.2.0
+        image: daocloud.io/piraeus/csi-node-driver-registrar:v1.2.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1175,7 +1176,7 @@ spec:
         - name: registration-dir
           mountPath: /registration/
       - name: piraeus-csi-plugin
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-csi:v0.7.4
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/all.dce.yaml
+++ b/deploy/all.dce.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: Always
         resources:
           limits:
@@ -140,7 +140,8 @@ spec:
       - name: init
         emptyDir: {}
       - name: data
-        emptyDir: {}
+        hostPath:
+          path: /var/lib/piraeus/etcd
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -219,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -338,7 +339,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -381,8 +382,6 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
-        - name: usr-local-bin
-          mountPath: /usr/local/bin
       containers:
       - name: satellite
         image: quay.azk8s.cn/piraeusdatastore/piraeus-server:v1.4.2
@@ -448,9 +447,6 @@ spec:
       - name: dev
         hostPath:
           path: /dev
-      - name: usr-local-bin
-        hostPath:
-          path: /usr/local/bin
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock
@@ -524,7 +520,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -547,7 +543,7 @@ spec:
           mountPath: /init
       containers:
       - name: scaler
-        image: quay.azk8s.cn/piraeusdatastore/piraeus-client:v1.0.11
+        image: quay.azk8s.cn/piraeusdatastore/piraeus-client:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/deploy/all.dce.yaml
+++ b/deploy/all.dce.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: Always
         resources:
           limits:
@@ -94,7 +94,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: daocloud.io/piraeus/etcd:v3.4.5
+        image: daocloud.io/piraeus/etcd:v3.4.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -220,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -261,12 +261,11 @@ spec:
               fieldPath: status.podIP
         args:
         - startController
-        - --stack-traces
         readinessProbe:
-          successThreshold: 3
-          failureThreshold: 3
           httpGet:
             port: 3370
+          successThreshold: 3
+          failureThreshold: 3
           periodSeconds: 5
         volumeMounts:
         - name: timezone
@@ -340,7 +339,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -411,9 +410,6 @@ spec:
               fieldPath: spec.nodeName
         args:
         - startSatellite
-        - --stack-traces
-        - --log-level
-        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -542,7 +538,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.4
+        image: daocloud.io/piraeus/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/all.dce.yaml
+++ b/deploy/all.dce.yaml
@@ -383,6 +383,10 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
       containers:
       - name: satellite
         image: daocloud.io/piraeus/piraeus-server:v1.4.2
@@ -408,6 +412,8 @@ spec:
         args:
         - startSatellite
         - --stack-traces
+        - --log-level
+        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -430,6 +436,8 @@ spec:
           mountPath: /dev
         - name: lib-modules
           mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
       volumes:
       - name: timezone
         hostPath:
@@ -458,6 +466,19 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: Always
         resources:
           limits:
@@ -94,7 +94,7 @@ spec:
           mountPath: /var/lib/etcd
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:v3.4.5
+        image: quay.io/coreos/etcd:v3.4.7
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -220,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -261,12 +261,11 @@ spec:
               fieldPath: status.podIP
         args:
         - startController
-        - --stack-traces
         readinessProbe:
-          successThreshold: 3
-          failureThreshold: 3
           httpGet:
             port: 3370
+          successThreshold: 3
+          failureThreshold: 3
           periodSeconds: 5
         volumeMounts:
         - name: timezone
@@ -340,7 +339,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -411,9 +410,6 @@ spec:
               fieldPath: spec.nodeName
         args:
         - startSatellite
-        - --stack-traces
-        - --log-level
-        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -542,7 +538,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: Always
         resources:
           limits:
@@ -140,7 +140,8 @@ spec:
       - name: init
         emptyDir: {}
       - name: data
-        emptyDir: {}
+        hostPath:
+          path: /var/lib/piraeus/etcd
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -219,7 +220,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -338,7 +339,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -381,8 +382,6 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
-        - name: usr-local-bin
-          mountPath: /usr/local/bin
       containers:
       - name: satellite
         image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
@@ -448,9 +447,6 @@ spec:
       - name: dev
         hostPath:
           path: /dev
-      - name: usr-local-bin
-        hostPath:
-          path: /usr/local/bin
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock
@@ -524,7 +520,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.3
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -547,7 +543,7 @@ spec:
           mountPath: /init
       containers:
       - name: scaler
-        image: quay.io/piraeusdatastore/piraeus-client:v1.0.11
+        image: quay.io/piraeusdatastore/piraeus-client:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -383,6 +383,10 @@ spec:
           mountPath: /lib/modules
         - name: opt-piraeus
           mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
       containers:
       - name: satellite
         image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
@@ -408,6 +412,8 @@ spec:
         args:
         - startSatellite
         - --stack-traces
+        - --log-level
+        - TRACE
         readinessProbe:
           successThreshold: 3
           failureThreshold: 3
@@ -430,6 +436,8 @@ spec:
           mountPath: /dev
         - name: lib-modules
           mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
       volumes:
       - name: timezone
         hostPath:
@@ -458,6 +466,19 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -307,7 +307,8 @@ data:
   INIT_DEBUG: "false"
   LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
   POOL_BASE_DIR: /var/lib/piraeus/storagepools
-  DRBD_IMG_TAG: v9.0.21
+  DRBD_IMG_REPO: quay.io/piraeusdatastore
+  DRBD_IMG_TAG: v9.0.22
   DRBD_IMG_PULL_POLICY: IfNotPresent
   MAP_HOST_LVM: "true"
 ---

--- a/dockerfiles/piraeus-init/Dockerfile
+++ b/dockerfiles/piraeus-init/Dockerfile
@@ -9,7 +9,8 @@ RUN set -x && \
     rm -f /var/cache/apk/* 
 
 RUN set -x && \
-    pip install kubernetes nsenter docker-py python-etcd
+    pip install kubernetes nsenter docker-py python-etcd && \
+    rm -vf /usr/local/bin/nsenter
 
 RUN set -x && \
     mkdir -vp /tmp/linstor && \

--- a/dockerfiles/piraeus-init/bin/cli.drbdadm.sh
+++ b/dockerfiles/piraeus-init/bin/cli.drbdadm.sh
@@ -1,0 +1,7 @@
+#!/bin/sh 
+
+docker run --rm --privileged -it --net host \
+-v /etc/drbd.conf:/etc/drbd.conf:ro \
+-v /etc/drbd.d:/etc/drbd.d:ro \
+-v /var/lib/linstor.d:/var/lib/linstor.d:ro \
+quay.io/piraeusdatastore/drbd-utils drbdadm "$@"

--- a/dockerfiles/piraeus-init/bin/cli.linstor.sh
+++ b/dockerfiles/piraeus-init/bin/cli.linstor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/sh 
 
 docker run --rm --net host -it \
 --env-file /opt/piraeus/client/env \

--- a/dockerfiles/piraeus-init/bin/init-node.sh
+++ b/dockerfiles/piraeus-init/bin/init-node.sh
@@ -41,7 +41,7 @@ else
         drbd_image_name=drbd9-centos8
     elif [[ "$( uname -a )" =~ Ubuntu ]]; then
         drbd_image_name=drbd9-bionic
-        [[ "$( uname -r )" =~ 4\.15\. ]] && mount_usr_lib=/usr/lib:/usr/lib:ro
+        # [[ "$( uname -r )" =~ 4\.15\. ]] && mount_usr_lib=/usr/lib:/usr/lib:ro
     fi
 
     # run drbd9 driver loader
@@ -55,6 +55,7 @@ fi
 
 # edit drbd.conf
 cat > /etc/drbd.conf << 'EOF'
+include "drbd.d/global_common.conf";
 include "/etc/drbd.d/*.res";
 include "/var/lib/linstor.d/*.res";
 EOF
@@ -85,7 +86,7 @@ while [ "${SECONDS}" -lt '3600' ];  do
     else
         echo '... controller is DOWN'
     fi
-    sleep 1
+    sleep 5
 done
 
 # register node to cluster

--- a/dockerfiles/piraeus-init/bin/init-node.sh
+++ b/dockerfiles/piraeus-init/bin/init-node.sh
@@ -35,11 +35,13 @@ echo 'Now cluster has nodes:'
 _linstor_node_list "$NODE_NAME"
 
 # find and inherit current image repo
-container_id="$( cat /proc/self/cgroup | grep :pids:/kubepods/pod"${POD_UID}" | awk -F/ '{print $NF}' )"
-image="$( _docker_ps | jq -r ".[] | select(.Id == \"${container_id}\") | .Image" )"
-echo "$image"
-[[ "$image" == "${image%/*}" ]] && image_repo='docker.io/library' || image_repo="${image%/*}"
-echo "$image_repo"
+# container_id="$( cat /proc/self/cgroup | grep :pids:/kubepods/pod"${POD_UID}" | awk -F/ '{print $NF}' )"
+# image_id="$( _docker_ps | jq -r ".[] | select(.Id == \"${container_id}\") | .ImageID" )"
+# echo "* Current image ID is $image_id"
+# image="$( _docker_images | jq -r ".[] | select(.Id == \"${image_id}\") | .RepoTags[0]" )"
+# echo "* Current image name: $image"
+# [[ "$image" == "${image%/*}" ]] && image_repo='docker.io/library' || image_repo="${image%/*}"
+# echo "* Current image repository is: $image_repo"
 
 # enable devicemapper thin-provisioning
 echo '* Enable dm_thin_pool'
@@ -71,7 +73,7 @@ else
     fi
 
     # run drbd9 driver loader
-    drbd_image_url="${image_repo}/${drbd_image_name}:${DRBD_IMG_TAG}"
+    drbd_image_url="${DRBD_IMG_REPO}/${drbd_image_name}:${DRBD_IMG_TAG}"
     echo "* Compile and load drbd module by image \"${drbd_image_url}\""
     if [[ "${DRBD_IMG_PULL_POLICY,,}" == "always" ]] || [[ "$( _docker_image_inspect "$drbd_image_url" | jq '.Id' )" == "null" ]]; then
         _docker_pull "$drbd_image_url"
@@ -81,7 +83,7 @@ fi
 
 # install linstor cli script
 echo "* Install local linstor cli"
-sed -i "s#quay.io/piraeusdatastore/#${image_repo}/#" /init/bin/linstor.sh
+sed -i "s#quay.io/piraeusdatastore/#${DRBD_IMG_REPO}/#" /init/bin/linstor.sh
 cli_dir="/opt/${POD_NAME/-*/}/client"
 mkdir -vp "$cli_dir"
 cp -vuf /init/bin/linstor.sh "${cli_dir}/linstor"

--- a/dockerfiles/piraeus-init/bin/init-node.sh
+++ b/dockerfiles/piraeus-init/bin/init-node.sh
@@ -87,4 +87,4 @@ mkdir -vp "$cli_dir"
 cp -vuf /init/bin/linstor.sh "${cli_dir}/linstor"
 cp -vuf /etc/resolv.conf "${cli_dir}/"
 printenv > "${cli_dir}/env"
-ln -fs "${cli_dir}/linstor"  /usr/local/bin/linstor
+nsenter -t1 -m -- ln -vfs "${cli_dir}/linstor"  /usr/local/bin/linstor

--- a/dockerfiles/piraeus-init/bin/init-scaler.sh
+++ b/dockerfiles/piraeus-init/bin/init-scaler.sh
@@ -12,5 +12,5 @@ while [ "${SECONDS}" -lt '3600' ];  do
     else
         echo '... this node is OFFLINE'
     fi
-    sleep 1
+    sleep 5
 done

--- a/dockerfiles/piraeus-init/bin/run-scaler.sh
+++ b/dockerfiles/piraeus-init/bin/run-scaler.sh
@@ -5,7 +5,7 @@
 # restart pod if configmap gets updated
 trap 'exit 0' SIGTERM SIGINT
 previous_checksum="$( sha256sum /var/run/task )"
-while sleep 2; do
+while sleep 5; do
     current_checksum="$( sha256sum /var/run/task )"
     [ "$current_checksum" != "$previous_checksum" ] && echo "* New task arrived!" && exit 0
 done


### PR DESCRIPTION
1. explicitly specify drbd image url
2. mapped etcd data dir to host
3. added drbdadm cli to host
4. fixed drbd v9.0.22 kmod compiling issue on Ubuntu 16
5. fixed a readme error about piraeus node label 