### PR TITLE
Fix issue#32 etcd reinitializes after etcd pod is respawned

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The hosts should use Docker as their container runtime and be running one of the
 
 ### Node selection
 
+The 3 nodes on which piraeus runs etcd clusters should be labelled as follows:
+
+```
+kubectl label nodes $NODE_NAME piraeus/etcd=true
+```
+
 The nodes on which piraeus should provide or consume storage should be labelled as follows:
 
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ kubectl -n piraeus-system exec -it piraeus-controller-0 -- linstor node list
 
 This should show that the selected nodes are `Online` at the LINSTOR level.
 
+### Upgrade
+
+`all.yaml` is only for installation.
+For upgrade, please use `upgrade.yaml`. It skips etcd upgrade (which is dangerous), and storageclass upgrade (which is immutable).
+
+```
+kubectl apply -f https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/deploy/upgrade.yaml
+```
+
+
 ### Using storage (demo)
 
 Piraeus preconfigures a `DfltStorPool` by using LINSTOR's `FileThin` backend, which is ready to use after yaml deployment.

--- a/artwork/.gitignore
+++ b/artwork/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/deploy.template/10_etcd.yaml
+++ b/deploy.template/10_etcd.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ etcd()
-  annotations: 
+  annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP

--- a/deploy.template/10_etcd.yaml
+++ b/deploy.template/10_etcd.yaml
@@ -10,9 +10,11 @@ metadata:
   labels:
     app.kubernetes.io/name: #@ name()
     app.kubernetes.io/component: #@ etcd()
+  annotations: 
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP
-  #! publishNotReadyAddresses: true
+  publishNotReadyAddresses: true
   ports:
   - name: client
     port: 2379
@@ -34,7 +36,7 @@ metadata:
     app.kubernetes.io/component: #@ etcd()
 spec:
   serviceName: #@ etcd()
-  #! podManagementPolicy: Parallel
+  podManagementPolicy: Parallel
   replicas: 3
   updateStrategy:
     type: RollingUpdate
@@ -66,8 +68,8 @@ spec:
             cpu: 100m
             memory: 100Mi
         env:
-        - name: ETCD_ENDPOINT
-          value: #@ etcdendpoint()
+        - name: CLUSTER_SIZE
+          value: '3'
         - name: PEER_PORT
           value: '2380'
         - name: CLIENT_PORT
@@ -155,10 +157,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              #! - key: piraeus/etcd
-              #!   operator: In
-              #!   values:
-              #!     - "true"
+              - key: piraeus/etcd
+                operator: In
+                values:
+                 - "true"
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       tolerations:

--- a/deploy.template/30_node.yaml
+++ b/deploy.template/30_node.yaml
@@ -59,11 +59,11 @@ spec:
         envFrom:
         - configMapRef:
             name:  #@ node()
-        env:    
+        env:
         - name: POD_UID
           valueFrom:
             fieldRef:
-              fieldPath: metadata.uid        
+              fieldPath: metadata.uid
         - name: POD_IP
           valueFrom:
             fieldRef:
@@ -201,11 +201,11 @@ spec:
           path: /etc/drbd.d
       #@ if map_host_lvm():
       - name: run-lvm
-        hostPath:           
+        hostPath:
           path: /run/lvm
       - name: run-udev
-        hostPath:           
-          path: /run/udev 
+        hostPath:
+          path: /run/udev
       #@ end
       #@ if map_host_linstor():
       - name: var-lib-linstor-d

--- a/deploy.template/31_scaler.yaml
+++ b/deploy.template/31_scaler.yaml
@@ -94,7 +94,7 @@ spec:
         - name: POD_UID
           valueFrom:
             fieldRef:
-              fieldPath: metadata.uid         
+              fieldPath: metadata.uid
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/deploy.template/42_sc.yaml
+++ b/deploy.template/42_sc.yaml
@@ -13,6 +13,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -31,6 +32,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -49,6 +51,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -67,6 +70,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -85,6 +89,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -102,6 +107,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -119,6 +125,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 
@@ -136,5 +143,6 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool

--- a/deploy.template/Makefile
+++ b/deploy.template/Makefile
@@ -3,7 +3,23 @@ SRC=$(sort $(wildcard *.yaml))
 DST=$(addprefix ../deploy/$(PREFIX),$(SRC))
 LAST=$(lastword $(DST))
 
-all: ../deploy/$(PREFIX)all.yaml cn dce
+all: ../deploy/$(PREFIX)all.yaml ../deploy/$(PREFIX)upgrade.yaml cn dce
+
+../deploy/$(PREFIX)all.yaml: $(DST)
+	:> $@
+	for f in $^; do \
+		cat $$f >> $@; \
+		[ "$$f" != $(LAST) ] && echo '---' >> $@ || true; \
+	done
+
+../deploy/$(PREFIX)upgrade.yaml: $(DST)
+	:> $@
+	for f in $^; do \
+		[ "$$f" = '../deploy/10_etcd.yaml' ] && continue; \
+		[ "$$f" = '../deploy/42_sc.yaml' ] && continue; \
+		cat $$f >> $@; \
+		[ "$$f" != $(LAST) ] && echo '---' >> $@ || true; \
+	done
 
 # for Chinese users, switch registries to daocloud registry, and tz to shanghai
 cn:
@@ -13,6 +29,12 @@ cn:
 	| sed 's#/usr/share/zoneinfo/Etc/UTC#/usr/share/zoneinfo/Asia/Shanghai#g' \
 	> ../deploy/all.cn.yaml
 
+	cat ../deploy/upgrade.yaml \
+	| sed 's#quay.io/piraeusdatastore#daocloud.io/piraeus#g' \
+	| sed 's#quay.io/.*/#daocloud.io/piraeus/#g' \
+	| sed 's#/usr/share/zoneinfo/Etc/UTC#/usr/share/zoneinfo/Asia/Shanghai#g' \
+	> ../deploy/upgrade.cn.yaml
+
 # for daocloud dce, fix etcds and controllers on kube-master nodes
 dce:
 	cat ../deploy/all.cn.yaml \
@@ -21,12 +43,11 @@ dce:
 	| sed '/ name: piraeus-csi-controller$$/,/DoesNotExist/ s/DoesNotExist/Exists/' \
 	> ../deploy/all.dce.yaml
 
-../deploy/$(PREFIX)all.yaml: $(DST)
-	:> $@
-	for f in $^; do \
-		cat $$f >> $@; \
-		[ "$$f" != $(LAST) ] && echo '---' >> $@ || true; \
-	done
+	cat ../deploy/upgrade.cn.yaml \
+	| sed '/ name: piraeus-etcd$$/,/DoesNotExist/ s/DoesNotExist/Exists/' \
+	| sed '/ name: piraeus-controller$$/,/DoesNotExist/ s/DoesNotExist/Exists/' \
+	| sed '/ name: piraeus-csi-controller$$/,/DoesNotExist/ s/DoesNotExist/Exists/' \
+	> ../deploy/upgrade.dce.yaml
 
 # check that PREFIX config exists.
 # Otherwise (GNU) make tries to create it via some implicit rule

--- a/deploy.template/config.yml
+++ b/deploy.template/config.yml
@@ -8,7 +8,7 @@ map_host_lvm: false
 set_priority_class: false
 registry: "quay.io/piraeusdatastore"
 etcdversion: "v3.4.7"
-initversion: "v0.5.5"
+initversion: "v0.5.6"
 contsatversion: "v1.4.2"
 csiversion: "v0.7.4"
 clientversion: "latest"

--- a/deploy/10_etcd.yaml
+++ b/deploy/10_etcd.yaml
@@ -6,8 +6,11 @@ metadata:
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-etcd
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP
+  publishNotReadyAddresses: true
   ports:
   - name: client
     port: 2379
@@ -29,6 +32,7 @@ metadata:
     app.kubernetes.io/component: piraeus-etcd
 spec:
   serviceName: piraeus-etcd
+  podManagementPolicy: Parallel
   replicas: 3
   updateStrategy:
     type: RollingUpdate
@@ -47,15 +51,15 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m
             memory: 100Mi
         env:
-        - name: ETCD_ENDPOINT
-          value: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+        - name: CLUSTER_SIZE
+          value: "3"
         - name: PEER_PORT
           value: "2380"
         - name: CLIENT_PORT
@@ -141,6 +145,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: piraeus/etcd
+                operator: In
+                values:
+                - "true"
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       tolerations:

--- a/deploy/20_controller.yaml
+++ b/deploy/20_controller.yaml
@@ -54,7 +54,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/30_node.yaml
+++ b/deploy/30_node.yaml
@@ -40,7 +40,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/deploy/31_scaler.yaml
+++ b/deploy/31_scaler.yaml
@@ -44,7 +44,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/42_sc.yaml
+++ b/deploy/42_sc.yaml
@@ -12,6 +12,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -46,6 +47,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---

--- a/deploy/42_sc.yaml
+++ b/deploy/42_sc.yaml
@@ -30,6 +30,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -65,6 +66,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -81,6 +83,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -97,6 +100,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -113,6 +117,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -129,5 +134,6 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool

--- a/deploy/all.cn.yaml
+++ b/deploy/all.cn.yaml
@@ -21,8 +21,11 @@ metadata:
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-etcd
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP
+  publishNotReadyAddresses: true
   ports:
   - name: client
     port: 2379
@@ -44,6 +47,7 @@ metadata:
     app.kubernetes.io/component: piraeus-etcd
 spec:
   serviceName: piraeus-etcd
+  podManagementPolicy: Parallel
   replicas: 3
   updateStrategy:
     type: RollingUpdate
@@ -62,15 +66,15 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m
             memory: 100Mi
         env:
-        - name: ETCD_ENDPOINT
-          value: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+        - name: CLUSTER_SIZE
+          value: "3"
         - name: PEER_PORT
           value: "2380"
         - name: CLIENT_PORT
@@ -156,6 +160,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: piraeus/etcd
+                operator: In
+                values:
+                - "true"
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       tolerations:
@@ -220,7 +228,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -339,7 +347,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -538,7 +546,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1344,6 +1352,7 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+fsType: xfs
 parameters:
   layerlist: drbd storage
   placementCount: "3"

--- a/deploy/all.cn.yaml
+++ b/deploy/all.cn.yaml
@@ -1324,6 +1324,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1341,6 +1342,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1352,13 +1354,13 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
-fsType: xfs
 parameters:
   layerlist: drbd storage
   placementCount: "3"
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1376,6 +1378,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1392,6 +1395,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1408,6 +1412,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1424,6 +1429,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1440,5 +1446,6 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool

--- a/deploy/all.dce.yaml
+++ b/deploy/all.dce.yaml
@@ -21,8 +21,11 @@ metadata:
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-etcd
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP
+  publishNotReadyAddresses: true
   ports:
   - name: client
     port: 2379
@@ -44,6 +47,7 @@ metadata:
     app.kubernetes.io/component: piraeus-etcd
 spec:
   serviceName: piraeus-etcd
+  podManagementPolicy: Parallel
   replicas: 3
   updateStrategy:
     type: RollingUpdate
@@ -62,15 +66,15 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m
             memory: 100Mi
         env:
-        - name: ETCD_ENDPOINT
-          value: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+        - name: CLUSTER_SIZE
+          value: "3"
         - name: PEER_PORT
           value: "2380"
         - name: CLIENT_PORT
@@ -156,6 +160,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: piraeus/etcd
+                operator: In
+                values:
+                - "true"
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
@@ -220,7 +228,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -339,7 +347,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -538,7 +546,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: daocloud.io/piraeus/piraeus-init:v0.5.5
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1344,6 +1352,7 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+fsType: xfs
 parameters:
   layerlist: drbd storage
   placementCount: "3"

--- a/deploy/all.dce.yaml
+++ b/deploy/all.dce.yaml
@@ -1324,6 +1324,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1341,6 +1342,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1352,13 +1354,13 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
-fsType: xfs
 parameters:
   layerlist: drbd storage
   placementCount: "3"
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1376,6 +1378,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1392,6 +1395,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1408,6 +1412,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1424,6 +1429,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1440,5 +1446,6 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -1324,6 +1324,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1341,6 +1342,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1352,13 +1354,13 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
-fsType: xfs
 parameters:
   layerlist: drbd storage
   placementCount: "3"
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1376,6 +1378,7 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1392,6 +1395,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1408,6 +1412,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1424,6 +1429,7 @@ parameters:
   placementPolicy: AutoPlace
   allowRemoteVolumeAccess: "true"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool
 ---
@@ -1440,5 +1446,6 @@ parameters:
   placementPolicy: FollowTopology
   allowRemoteVolumeAccess: "false"
   disklessOnRemaining: "false"
+  csi.storage.k8s.io/fstype: xfs
   mountOpts: noatime,discard
   storagePool: DfltStorPool

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -21,8 +21,11 @@ metadata:
   labels:
     app.kubernetes.io/name: piraeus
     app.kubernetes.io/component: piraeus-etcd
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP
+  publishNotReadyAddresses: true
   ports:
   - name: client
     port: 2379
@@ -44,6 +47,7 @@ metadata:
     app.kubernetes.io/component: piraeus-etcd
 spec:
   serviceName: piraeus-etcd
+  podManagementPolicy: Parallel
   replicas: 3
   updateStrategy:
     type: RollingUpdate
@@ -62,15 +66,15 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m
             memory: 100Mi
         env:
-        - name: ETCD_ENDPOINT
-          value: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+        - name: CLUSTER_SIZE
+          value: "3"
         - name: PEER_PORT
           value: "2380"
         - name: CLIENT_PORT
@@ -156,6 +160,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: piraeus/etcd
+                operator: In
+                values:
+                - "true"
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       tolerations:
@@ -220,7 +228,7 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -339,7 +347,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -538,7 +546,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: init
-        image: quay.io/piraeusdatastore/piraeus-init:v0.5.5
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1344,6 +1352,7 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+fsType: xfs
 parameters:
   layerlist: drbd storage
   placementCount: "3"

--- a/deploy/upgrade.cn.yaml
+++ b/deploy/upgrade.cn.yaml
@@ -1,0 +1,1153 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus-system
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  ETCD_ENDPOINTS: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3370
+    name: rest-api
+    targetPort: 3370
+  selector:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+spec:
+  serviceName: piraeus-controller
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-controller
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - name: init
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-controller
+        args:
+        - initController
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+      containers:
+      - name: controller
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        ports:
+        - name: rest-api
+          containerPort: 3370
+          hostPort: 3370
+        - name: plain
+          containerPort: 3376
+          hostPort: 3376
+        - name: ssl
+          containerPort: 3377
+          hostPort: 3377
+        env:
+        - name: THIS_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - startController
+        readinessProbe:
+          httpGet:
+            port: 3370
+          successThreshold: 3
+          failureThreshold: 3
+          periodSeconds: 5
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /etc/linstor
+          subPath: etc/linstor
+        - name: log
+          mountPath: /var/log/linstor-controller
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: init
+        emptyDir: {}
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-controller
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-node
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+  POOL_BASE_DIR: /var/lib/piraeus/storagepools
+  DRBD_IMG_REPO: daocloud.io/piraeus
+  DRBD_IMG_TAG: v9.0.22
+  DRBD_IMG_PULL_POLICY: IfNotPresent
+  MAP_HOST_LVM: "true"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-node
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-node
+    spec:
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - initNode
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: opt-piraeus
+          mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
+      containers:
+      - name: satellite
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 300m
+            memory: 300Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - startSatellite
+        readinessProbe:
+          successThreshold: 3
+          failureThreshold: 3
+          tcpSocket:
+            port: 3366
+          periodSeconds: 5
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: init
+          mountPath: /usr/bin/pre-start.sh
+          subPath: bin/prestart-node.sh
+        - name: log
+          mountPath: /var/log/linstor-satellite
+        - name: var-lib-piraeus
+          mountPath: /var/lib/piraeus
+        - name: dev
+          mountPath: /dev
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: init
+        emptyDir: {}
+      - name: opt-piraeus
+        hostPath:
+          path: /opt/piraeus
+      - name: var-lib-piraeus
+        hostPath:
+          path: /var/lib/piraeus
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-satellite
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+  POOL_BASE_DIR: /var/lib/piraeus/storagepools
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler-task
+  namespace: piraeus-system
+data:
+  task: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-scaler
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-scaler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-scaler
+    spec:
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-scaler
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - initScaler
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+      containers:
+      - name: scaler
+        image: daocloud.io/piraeus/piraeus-client:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-scaler
+        env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - /init/bin/run-scaler.sh
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: run
+          mountPath: /var/run/task
+          subPath: task
+        - name: var-lib-piraeus
+          mountPath: /var/lib/piraeus
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: init
+        emptyDir: {}
+      - name: run
+        configMap:
+          name: piraeus-scaler-task
+          items:
+          - key: task
+            path: task
+            mode: 493
+      - name: var-lib-piraeus
+        hostPath:
+          path: /var/lib/piraeus
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler-task
+  namespace: piraeus-system
+data:
+  task: |
+    #!/bin/sh -x
+    pool_name=DfltStorPool
+    pool_dir="${POOL_BASE_DIR}/${pool_name}"
+    mkdir -vp "$pool_dir"
+    linstor storage-pool list -n "$NODE_NAME" -s "$pool_name" | grep -vw "$pool_name" && \
+    linstor storage-pool create filethin "$NODE_NAME" "$pool_name" "$pool_dir"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: piraeus-csi-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-csi-controller
+spec:
+  serviceName: piraeus-csi-controller
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-controller
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-csi-controller
+    spec:
+      serviceAccount: piraeus-csi-controller-sa
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: csi-provisioner
+        image: daocloud.io/piraeus/csi-provisioner:v1.5.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-address=$(ADDRESS)
+        - --v=5
+        - --feature-gates=Topology=true
+        - --timeout=120s
+        - --enable-leader-election
+        - --leader-election-type=leases
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-attacher
+        image: daocloud.io/piraeus/csi-attacher:v2.1.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --timeout=120s
+        - --leader-election=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-snapshotter
+        image: daocloud.io/piraeus/csi-snapshotter:v2.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-address=$(ADDRESS)
+        - --timeout=120s
+        - --leader-election=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-cluster-driver-registrar
+        image: daocloud.io/piraeus/csi-cluster-driver-registrar:v1.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --pod-info-mount-version="v1"
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: piraeus-csi-plugin
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-endpoint=$(CSI_ENDPOINT)
+        - --node=$(KUBE_NODE_NAME)
+        - --linstor-endpoint=$(LS_CONTROLLERS)
+        - --log-level=debug
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LS_CONTROLLERS
+          value: http://piraeus-controller.piraeus-system.svc.cluster.local:3370
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: socket-dir
+        emptyDir: {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - piraeus-csi-controller
+            topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-provisioner-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-attacher-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-attacher-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-cluster-driver-registrar-role
+rules:
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-cluster-driver-registrar-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-cluster-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-snapshotter-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-snapshotter-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: linstor.csi.linbit.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-csi-node
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-csi-node
+    spec:
+      serviceAccount: piraeus-csi-node-sa
+      restartPolicy: Always
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: csi-node-driver-registrar
+        image: daocloud.io/piraeus/csi-node-driver-registrar:v1.2.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/linstor.csi.linbit.com /registration/linstor.csi.linbit.com-reg.sock
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/linstor.csi.linbit.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: plugin-dir
+          mountPath: /csi/
+        - name: registration-dir
+          mountPath: /registration/
+      - name: piraeus-csi-plugin
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-endpoint=$(CSI_ENDPOINT)
+        - --node=$(KUBE_NODE_NAME)
+        - --linstor-endpoint=$(LS_CONTROLLERS)
+        - --log-level=debug
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LS_CONTROLLERS
+          value: http://piraeus-controller.piraeus-system.svc.cluster.local:3370
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+        - name: device-dir
+          mountPath: /dev
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: DirectoryOrCreate
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/linstor.csi.linbit.com/
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: piraeus-csi-node-sa
+  namespace: piraeus-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-node-driver-registrar-role
+  namespace: piraeus-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-node-driver-registrar-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-node-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-node-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/deploy/upgrade.dce.yaml
+++ b/deploy/upgrade.dce.yaml
@@ -1,0 +1,1153 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus-system
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  ETCD_ENDPOINTS: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3370
+    name: rest-api
+    targetPort: 3370
+  selector:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+spec:
+  serviceName: piraeus-controller
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-controller
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - name: init
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-controller
+        args:
+        - initController
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+      containers:
+      - name: controller
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        ports:
+        - name: rest-api
+          containerPort: 3370
+          hostPort: 3370
+        - name: plain
+          containerPort: 3376
+          hostPort: 3376
+        - name: ssl
+          containerPort: 3377
+          hostPort: 3377
+        env:
+        - name: THIS_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - startController
+        readinessProbe:
+          httpGet:
+            port: 3370
+          successThreshold: 3
+          failureThreshold: 3
+          periodSeconds: 5
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /etc/linstor
+          subPath: etc/linstor
+        - name: log
+          mountPath: /var/log/linstor-controller
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: init
+        emptyDir: {}
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-controller
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-node
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+  POOL_BASE_DIR: /var/lib/piraeus/storagepools
+  DRBD_IMG_REPO: daocloud.io/piraeus
+  DRBD_IMG_TAG: v9.0.22
+  DRBD_IMG_PULL_POLICY: IfNotPresent
+  MAP_HOST_LVM: "true"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-node
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-node
+    spec:
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - initNode
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: opt-piraeus
+          mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
+      containers:
+      - name: satellite
+        image: daocloud.io/piraeus/piraeus-server:v1.4.2
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 300m
+            memory: 300Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - startSatellite
+        readinessProbe:
+          successThreshold: 3
+          failureThreshold: 3
+          tcpSocket:
+            port: 3366
+          periodSeconds: 5
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: init
+          mountPath: /usr/bin/pre-start.sh
+          subPath: bin/prestart-node.sh
+        - name: log
+          mountPath: /var/log/linstor-satellite
+        - name: var-lib-piraeus
+          mountPath: /var/lib/piraeus
+        - name: dev
+          mountPath: /dev
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: init
+        emptyDir: {}
+      - name: opt-piraeus
+        hostPath:
+          path: /opt/piraeus
+      - name: var-lib-piraeus
+        hostPath:
+          path: /var/lib/piraeus
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-satellite
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+  POOL_BASE_DIR: /var/lib/piraeus/storagepools
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler-task
+  namespace: piraeus-system
+data:
+  task: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-scaler
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-scaler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-scaler
+    spec:
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: daocloud.io/piraeus/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-scaler
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - initScaler
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+      containers:
+      - name: scaler
+        image: daocloud.io/piraeus/piraeus-client:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-scaler
+        env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - /init/bin/run-scaler.sh
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: run
+          mountPath: /var/run/task
+          subPath: task
+        - name: var-lib-piraeus
+          mountPath: /var/lib/piraeus
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: init
+        emptyDir: {}
+      - name: run
+        configMap:
+          name: piraeus-scaler-task
+          items:
+          - key: task
+            path: task
+            mode: 493
+      - name: var-lib-piraeus
+        hostPath:
+          path: /var/lib/piraeus
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler-task
+  namespace: piraeus-system
+data:
+  task: |
+    #!/bin/sh -x
+    pool_name=DfltStorPool
+    pool_dir="${POOL_BASE_DIR}/${pool_name}"
+    mkdir -vp "$pool_dir"
+    linstor storage-pool list -n "$NODE_NAME" -s "$pool_name" | grep -vw "$pool_name" && \
+    linstor storage-pool create filethin "$NODE_NAME" "$pool_name" "$pool_dir"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: piraeus-csi-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-csi-controller
+spec:
+  serviceName: piraeus-csi-controller
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-controller
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-csi-controller
+    spec:
+      serviceAccount: piraeus-csi-controller-sa
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: csi-provisioner
+        image: daocloud.io/piraeus/csi-provisioner:v1.5.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-address=$(ADDRESS)
+        - --v=5
+        - --feature-gates=Topology=true
+        - --timeout=120s
+        - --enable-leader-election
+        - --leader-election-type=leases
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-attacher
+        image: daocloud.io/piraeus/csi-attacher:v2.1.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --timeout=120s
+        - --leader-election=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-snapshotter
+        image: daocloud.io/piraeus/csi-snapshotter:v2.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-address=$(ADDRESS)
+        - --timeout=120s
+        - --leader-election=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-cluster-driver-registrar
+        image: daocloud.io/piraeus/csi-cluster-driver-registrar:v1.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --pod-info-mount-version="v1"
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: piraeus-csi-plugin
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-endpoint=$(CSI_ENDPOINT)
+        - --node=$(KUBE_NODE_NAME)
+        - --linstor-endpoint=$(LS_CONTROLLERS)
+        - --log-level=debug
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LS_CONTROLLERS
+          value: http://piraeus-controller.piraeus-system.svc.cluster.local:3370
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: socket-dir
+        emptyDir: {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - piraeus-csi-controller
+            topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-provisioner-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-attacher-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-attacher-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-cluster-driver-registrar-role
+rules:
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-cluster-driver-registrar-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-cluster-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-snapshotter-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-snapshotter-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: linstor.csi.linbit.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-csi-node
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-csi-node
+    spec:
+      serviceAccount: piraeus-csi-node-sa
+      restartPolicy: Always
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: csi-node-driver-registrar
+        image: daocloud.io/piraeus/csi-node-driver-registrar:v1.2.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/linstor.csi.linbit.com /registration/linstor.csi.linbit.com-reg.sock
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/linstor.csi.linbit.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: plugin-dir
+          mountPath: /csi/
+        - name: registration-dir
+          mountPath: /registration/
+      - name: piraeus-csi-plugin
+        image: daocloud.io/piraeus/piraeus-csi:v0.7.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-endpoint=$(CSI_ENDPOINT)
+        - --node=$(KUBE_NODE_NAME)
+        - --linstor-endpoint=$(LS_CONTROLLERS)
+        - --log-level=debug
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LS_CONTROLLERS
+          value: http://piraeus-controller.piraeus-system.svc.cluster.local:3370
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+        - name: device-dir
+          mountPath: /dev
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Asia/Shanghai
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: DirectoryOrCreate
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/linstor.csi.linbit.com/
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: piraeus-csi-node-sa
+  namespace: piraeus-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-node-driver-registrar-role
+  namespace: piraeus-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-node-driver-registrar-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-node-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-node-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/deploy/upgrade.yaml
+++ b/deploy/upgrade.yaml
@@ -1,0 +1,1153 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus-system
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: piraeus-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  ETCD_ENDPOINTS: piraeus-etcd.piraeus-system.svc.cluster.local:2379
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3370
+    name: rest-api
+    targetPort: 3370
+  selector:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: piraeus-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-controller
+spec:
+  serviceName: piraeus-controller
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-controller
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - name: init
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-controller
+        args:
+        - initController
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+      containers:
+      - name: controller
+        image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        ports:
+        - name: rest-api
+          containerPort: 3370
+          hostPort: 3370
+        - name: plain
+          containerPort: 3376
+          hostPort: 3376
+        - name: ssl
+          containerPort: 3377
+          hostPort: 3377
+        env:
+        - name: THIS_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - startController
+        readinessProbe:
+          httpGet:
+            port: 3370
+          successThreshold: 3
+          failureThreshold: 3
+          periodSeconds: 5
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /etc/linstor
+          subPath: etc/linstor
+        - name: log
+          mountPath: /var/log/linstor-controller
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Etc/UTC
+      - name: init
+        emptyDir: {}
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-controller
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-node
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+  POOL_BASE_DIR: /var/lib/piraeus/storagepools
+  DRBD_IMG_REPO: quay.io/piraeusdatastore
+  DRBD_IMG_TAG: v9.0.22
+  DRBD_IMG_PULL_POLICY: IfNotPresent
+  MAP_HOST_LVM: "true"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-node
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-node
+    spec:
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - initNode
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: opt-piraeus
+          mountPath: /opt/piraeus
+        - name: drbd-conf
+          mountPath: /etc/drbd.conf
+        - name: etc-drbd-d
+          mountPath: /etc/drbd.d
+      containers:
+      - name: satellite
+        image: quay.io/piraeusdatastore/piraeus-server:v1.4.2
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 300m
+            memory: 300Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-node
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - startSatellite
+        readinessProbe:
+          successThreshold: 3
+          failureThreshold: 3
+          tcpSocket:
+            port: 3366
+          periodSeconds: 5
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: init
+          mountPath: /usr/bin/pre-start.sh
+          subPath: bin/prestart-node.sh
+        - name: log
+          mountPath: /var/log/linstor-satellite
+        - name: var-lib-piraeus
+          mountPath: /var/lib/piraeus
+        - name: dev
+          mountPath: /dev
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: var-lib-linstor-d
+          mountPath: /var/lib/linstor.d
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Etc/UTC
+      - name: init
+        emptyDir: {}
+      - name: opt-piraeus
+        hostPath:
+          path: /opt/piraeus
+      - name: var-lib-piraeus
+        hostPath:
+          path: /var/lib/piraeus
+      - name: log
+        hostPath:
+          path: /var/log/piraeus/linstor-satellite
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: drbd-conf
+        hostPath:
+          path: /etc/drbd.conf
+          type: FileOrCreate
+      - name: etc-drbd-d
+        hostPath:
+          path: /etc/drbd.d
+      - name: var-lib-linstor-d
+        hostPath:
+          path: /var/lib/linstor.d
+      - name: etc-linstor
+        hostPath:
+          path: /etc/linstor
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler
+  namespace: piraeus-system
+data:
+  INIT_DEBUG: "false"
+  LS_CONTROLLERS: piraeus-controller.piraeus-system.svc.cluster.local:3370
+  POOL_BASE_DIR: /var/lib/piraeus/storagepools
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler-task
+  namespace: piraeus-system
+data:
+  task: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-scaler
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-scaler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-scaler
+    spec:
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: init
+        image: quay.io/piraeusdatastore/piraeus-init:v0.5.6
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-scaler
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - initScaler
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+      containers:
+      - name: scaler
+        image: quay.io/piraeusdatastore/piraeus-client:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: piraeus-scaler
+        env:
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - /init/bin/run-scaler.sh
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: init
+          mountPath: /init
+        - name: run
+          mountPath: /var/run/task
+          subPath: task
+        - name: var-lib-piraeus
+          mountPath: /var/lib/piraeus
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: usr-src
+          mountPath: /usr/src
+        - name: lib-modules
+          mountPath: /lib/modules
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Etc/UTC
+      - name: init
+        emptyDir: {}
+      - name: run
+        configMap:
+          name: piraeus-scaler-task
+          items:
+          - key: task
+            path: task
+            mode: 493
+      - name: var-lib-piraeus
+        hostPath:
+          path: /var/lib/piraeus
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-scaler-task
+  namespace: piraeus-system
+data:
+  task: |
+    #!/bin/sh -x
+    pool_name=DfltStorPool
+    pool_dir="${POOL_BASE_DIR}/${pool_name}"
+    mkdir -vp "$pool_dir"
+    linstor storage-pool list -n "$NODE_NAME" -s "$pool_name" | grep -vw "$pool_name" && \
+    linstor storage-pool create filethin "$NODE_NAME" "$pool_name" "$pool_dir"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: piraeus-csi-controller
+  namespace: piraeus-system
+  labels:
+    app.kubernetes.io/name: piraeus
+    app.kubernetes.io/component: piraeus-csi-controller
+spec:
+  serviceName: piraeus-csi-controller
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-controller
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-csi-controller
+    spec:
+      serviceAccount: piraeus-csi-controller-sa
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: csi-provisioner
+        image: quay.io/k8scsi/csi-provisioner:v1.5.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-address=$(ADDRESS)
+        - --v=5
+        - --feature-gates=Topology=true
+        - --timeout=120s
+        - --enable-leader-election
+        - --leader-election-type=leases
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-attacher
+        image: quay.io/k8scsi/csi-attacher:v2.1.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --timeout=120s
+        - --leader-election=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-snapshotter
+        image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-address=$(ADDRESS)
+        - --timeout=120s
+        - --leader-election=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-cluster-driver-registrar
+        image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --pod-info-mount-version="v1"
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: piraeus-csi-plugin
+        image: quay.io/piraeusdatastore/piraeus-csi:v0.7.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-endpoint=$(CSI_ENDPOINT)
+        - --node=$(KUBE_NODE_NAME)
+        - --linstor-endpoint=$(LS_CONTROLLERS)
+        - --log-level=debug
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LS_CONTROLLERS
+          value: http://piraeus-controller.piraeus-system.svc.cluster.local:3370
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Etc/UTC
+      - name: socket-dir
+        emptyDir: {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - piraeus-csi-controller
+            topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-provisioner-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-attacher-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-attacher-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-cluster-driver-registrar-role
+rules:
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-cluster-driver-registrar-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-cluster-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-snapshotter-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-controller-snapshotter-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-controller-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-controller-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: linstor.csi.linbit.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: piraeus-csi-node
+  namespace: piraeus-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: piraeus
+      app.kubernetes.io/component: piraeus-csi-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: piraeus
+        app.kubernetes.io/component: piraeus-csi-node
+    spec:
+      serviceAccount: piraeus-csi-node-sa
+      restartPolicy: Always
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: csi-node-driver-registrar
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/linstor.csi.linbit.com /registration/linstor.csi.linbit.com-reg.sock
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/linstor.csi.linbit.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: plugin-dir
+          mountPath: /csi/
+        - name: registration-dir
+          mountPath: /registration/
+      - name: piraeus-csi-plugin
+        image: quay.io/piraeusdatastore/piraeus-csi:v0.7.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        args:
+        - --csi-endpoint=$(CSI_ENDPOINT)
+        - --node=$(KUBE_NODE_NAME)
+        - --linstor-endpoint=$(LS_CONTROLLERS)
+        - --log-level=debug
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: LS_CONTROLLERS
+          value: http://piraeus-controller.piraeus-system.svc.cluster.local:3370
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: timezone
+          mountPath: /etc/localtime
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+        - name: device-dir
+          mountPath: /dev
+      volumes:
+      - name: timezone
+        hostPath:
+          path: /usr/share/zoneinfo/Etc/UTC
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: DirectoryOrCreate
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/linstor.csi.linbit.com/
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: piraeus/node
+                operator: In
+                values:
+                - "true"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: piraeus-csi-node-sa
+  namespace: piraeus-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-node-driver-registrar-role
+  namespace: piraeus-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: piraeus-csi-node-driver-registrar-binding
+subjects:
+- kind: ServiceAccount
+  name: piraeus-csi-node-sa
+  namespace: piraeus-system
+roleRef:
+  kind: ClusterRole
+  name: piraeus-csi-node-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/dockerfiles/piraeus-init/Dockerfile
+++ b/dockerfiles/piraeus-init/Dockerfile
@@ -1,25 +1,25 @@
 FROM python:3-alpine
 MAINTAINER Alex Zheng <alex.zheng@daocloud.io>
 
-ENV LINSTOR_API_PY_VER 1.0.11
+# ENV LINSTOR_API_PY_VER 1.0.11
 
 RUN set -x && \
     apk update && \
     apk add bash jq curl libcurl kmod && \
     rm -f /var/cache/apk/* 
 
-RUN set -x && \
-    pip install kubernetes nsenter docker-py python-etcd && \
-    rm -vf /usr/local/bin/nsenter
+# RUN set -x && \
+#     pip install kubernetes nsenter docker-py python-etcd && \
+#     rm -vf /usr/local/bin/nsenter
 
-RUN set -x && \
-    mkdir -vp /tmp/linstor && \
-    cd /tmp/linstor && \
-    curl -LO "https://github.com/LINBIT/linstor-api-py/archive/v${LINSTOR_API_PY_VER}.tar.gz" && \
-    tar -zxf "v${LINSTOR_API_PY_VER}.tar.gz" && \
-    cd "linstor-api-py-${LINSTOR_API_PY_VER}" && \
-    ./setup.py install && \
-    rm -vfr /tmp/linstor
+# RUN set -x && \
+#     mkdir -vp /tmp/linstor && \
+#     cd /tmp/linstor && \
+#     curl -LO "https://github.com/LINBIT/linstor-api-py/archive/v${LINSTOR_API_PY_VER}.tar.gz" && \
+#     tar -zxf "v${LINSTOR_API_PY_VER}.tar.gz" && \
+#     cd "linstor-api-py-${LINSTOR_API_PY_VER}" && \
+#     ./setup.py install && \
+#     rm -vfr /tmp/linstor
 
 ADD . /files/
 

--- a/dockerfiles/piraeus-init/bin/cli.drbdadm.sh
+++ b/dockerfiles/piraeus-init/bin/cli.drbdadm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 docker run --rm --privileged -it --net host \
 -v /etc/drbd.conf:/etc/drbd.conf:ro \

--- a/dockerfiles/piraeus-init/bin/cli.linstor.sh
+++ b/dockerfiles/piraeus-init/bin/cli.linstor.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 docker run --rm --net host -it \
 --env-file /opt/piraeus/client/env \

--- a/dockerfiles/piraeus-init/bin/init-etcd.sh
+++ b/dockerfiles/piraeus-init/bin/init-etcd.sh
@@ -1,30 +1,9 @@
 #!/bin/bash -ex
 
-source /init/bin/lib.etcd.sh
+# Get statefulset name
+pod_sts="${POD_NAME/-[0-9]*/}"
 
-# Get set name
-pod_set="${POD_NAME/-[0-9]*/}"
-
-# create data dir and backup the old if exits
-_etcd_reset_data_dir
-
-# Assemble cluster
-if _etcd_is_healthy "$ETCD_ENDPOINT"; then
-    # clean up duplicated member in case prestop cleanup fails
-    _etcd_has_old_member "$POD_NAME" && \
-    _etcd_remove_member "$POD_NAME" && \
-    _etcd_reset_data_dir
-
-    cluster_state=existing
-    cluster="$( _etcd_cluster ),${POD_NAME}=http://${POD_IP}:${PEER_PORT}"
-
-    _etcd_has_member "$POD_NAME" || \
-    _etcd_add_member "$POD_NAME" "http://${POD_IP}:${PEER_PORT}"
-else
-    cluster_state=new
-    cluster="${POD_NAME}=http://${POD_IP}:${PEER_PORT}"
-fi
-
+cluster=$( seq 0 $(( CLUSTER_SIZE - 1 )) | xargs -tI % echo "${pod_sts}-%=http://${pod_sts}-%.${pod_sts}:${PEER_PORT}" | paste -sd "," - )
 
 # write config file
 cat > /init/etc/etcd/etcd.conf << EOF
@@ -34,9 +13,9 @@ listen-peer-urls:            http://${POD_IP}:${PEER_PORT}
 listen-client-urls:          http://${POD_IP}:${CLIENT_PORT},http://127.0.0.1:${CLIENT_PORT}
 advertise-client-urls:       http://${POD_IP}:${CLIENT_PORT}
 initial-advertise-peer-urls: http://${POD_IP}:${PEER_PORT}
-initial-cluster-token:       ${pod_set}
+initial-cluster-token:       ${pod_sts}
 initial-cluster:             ${cluster}
-initial-cluster-state:       ${cluster_state}
+initial-cluster-state:       new
 data-dir:                    /var/lib/etcd/data
 enable-v2:                   true
 EOF

--- a/dockerfiles/piraeus-init/bin/lib.etcd.sh
+++ b/dockerfiles/piraeus-init/bin/lib.etcd.sh
@@ -49,10 +49,9 @@ EOF
     | jq '.'
 }
 
-_etcd_reset_data_dir() {
+_etcd_backup_data_dir() {
     timestamp="$( date +%Y-%m-%d_%H-%M-%S )"
     data_dir=/var/lib/etcd/data
     [ -d "$data_dir" ] && \
-    mv -vf "$data_dir" "${data_dir}.${timestamp}"
-    mkdir -vp "$data_dir"
+    cp -vrf "$data_dir" "${data_dir}.${timestamp}"
 }

--- a/dockerfiles/piraeus-init/bin/lib.etcd.sh
+++ b/dockerfiles/piraeus-init/bin/lib.etcd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 _curl () {
     curl -Ss --connect-timeout 1 --retry 3 --retry-delay 0 "$@"
@@ -28,7 +28,7 @@ _etcd_cluster() {
 
 _etcd_member_id() {
     _curl "${ETCD_ENDPOINT}"/v2/members | jq -r ".members[] | select(.name==\"$1\").id"
-} 
+}
 
 _etcd_remove_member() {
     member_id="$( _etcd_member_id "$1" )"

--- a/dockerfiles/piraeus-init/bin/lib.linstor.sh
+++ b/dockerfiles/piraeus-init/bin/lib.linstor.sh
@@ -79,8 +79,8 @@ _linstor_storage_pool_list() {
 _linstor_create_storage_pool() {
     cat > /init/tmp/.data.json << EOF
 {
-    "storage_pool_name": "$3", 
-    "provider_kind": "$1", 
+    "storage_pool_name": "$3",
+    "provider_kind": "$1",
     "props": {
         "StorDriver/FileDir": "$4"
     }

--- a/dockerfiles/piraeus-init/bin/prestart-node.sh
+++ b/dockerfiles/piraeus-init/bin/prestart-node.sh
@@ -8,5 +8,5 @@ if [ "$MAP_HOST_LVM" = 'true' ]; then
 #!/bin/sh
 nsenter --target 1 --mount --uts --ipc --net --pid -- "$(basename $0)" "$@"
 EOF
-    chmod +x "$cmdpath" 
+    chmod +x "$cmdpath"
 fi

--- a/dockerfiles/piraeus-init/bin/prestop-etcd.sh
+++ b/dockerfiles/piraeus-init/bin/prestop-etcd.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-# remove this member from the cluster and clean up the data dir
+data_dir=/var/lib/etcd/data
+# backup data dir if not empty
+if [ -d "$data_dir" ] && [ "$( ls -A "$data_dir" )" ]; then
+    mod_time="$( date +%Y-%m-%d_%H-%M-%S -r "$data_dir" )"
+    cp -vfr "$data_dir" "${data_dir}_${mod_time}"
+fi
 
-member_id="$( etcdctl member list -w fields | awk '/"MemberID"/ {print $NF}' )"
-
-etcdctl member remove "$( printf "%x" "$member_id" )"
-
-mv -vf /var/lib/etcd/data "/var/lib/etcd/data.$(date +%Y-%m-%d_%H-%M-%S)"
+etcdctl get --prefix "LINSTOR/" -w simple > "${data_dir}_${mod_time}/keys.txt"
+etcdctl get --prefix "LINSTOR/" -w json > "${data_dir}_${mod_time}/keys.json"


### PR DESCRIPTION
issue#32 etcd reinitializes after etcd pod is respawned

Current etcd node will leave etcd cluster, reinitialize and rejoin cluster after etcd pod is respawned, which is meant to allow etcd cluster to expand and shrink along with etcd statefulset. It assumes users will always make changes to etcd cluster in an orderly node-by-node fashion.  

However, per issue#32 and another user's report on slack, people might respawn all the etcd pods at the same time during upgrade or reboot test. 

Therefore, this pull request changes etcd deployment to a fixed 3-node configuration, and also makes node affinity mandatory for etcd pods. During pod respawn, etcd data dir will stay consistent and also backed up. 

Other changes: 
1. update.yaml is added to avoid upgrade etcd (which is dangerous) and upgrade storageclass (which is immutable). 
1. added `csi.storage.k8s.io/fstype: xfs` to default storageclass
1. piraeus-init is updated to v0.5.6


