### PR TITLE
add k8s-await-election helper to piraeus server

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -31,5 +31,10 @@ EXPOSE 3366/tcp 3367/tcp
 
 COPY entry.sh /usr/bin/piraeus-entry.sh
 
+ARG ARCH
+ARG K8S_AWAIT_ELECTION_VERSION
+
+RUN wget https://github.com/LINBIT/k8s-await-election/releases/download/${K8S_AWAIT_ELECTION_VERSION}/k8s-await-election-${K8S_AWAIT_ELECTION_VERSION}-linux-${ARCH}.tar.gz -O - | tar -xvz -C /usr/bin/
+
 CMD ["startSatellite"]
-ENTRYPOINT ["/usr/bin/piraeus-entry.sh"]
+ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/dockerfiles/piraeus-server/Makefile
+++ b/dockerfiles/piraeus-server/Makefile
@@ -1,5 +1,7 @@
 PROJECT ?= piraeus-server
 REGISTRY ?= piraeusdatastore
+K8S_AWAIT_ELECTION_VERSION ?= v0.1.0
+ARCH ?= amd64
 TAG ?= latest
 NOCACHE ?= false
 
@@ -10,7 +12,7 @@ all: update upload
 
 .PHONY: update
 update:
-	docker build --no-cache=$(NOCACHE) -t $(PROJECT):$(TAG) .
+	docker build --build-arg K8S_AWAIT_ELECTION_VERSION=$(K8S_AWAIT_ELECTION_VERSION) --build-arg ARCH=$(ARCH) --no-cache=$(NOCACHE) -t $(PROJECT):$(TAG) .
 	docker tag $(PROJECT):$(TAG) $(PROJECT):latest
 
 .PHONY: upload


### PR DESCRIPTION
This entrypoint enables multiple replicas for LINSTOR controllers.
The basic principle is that only one controller is running at any
point in time. k8s leader election is used to coordinate which pod
gets to start the controller process.

If a controller dies or loses leader status another way, the process
is killed and another pod get to start the controller process.

Required for https://github.com/piraeusdatastore/piraeus-operator/issues/56