### PR TITLE
automatic CI builds for piraeus-server images

### DIFF
--- a/.github/workflows/build-piraeus-server.yaml
+++ b/.github/workflows/build-piraeus-server.yaml
@@ -1,0 +1,26 @@
+name: Build piraeus-server
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - dockerfiles/piraeus-server/*
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build images
+        run: |
+          cd dockerfiles/piraeus-server
+          make update
+      - name: login to registry
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          docker login --username=${DOCKER_USERNAME} --password-stdin "quay.io" <<< "${DOCKER_PASSWORD}"
+      - name: push images
+        run: |
+          cd dockerfiles/piraeus-server
+          make upload REGISTRY="quay.io/piraeusdatastore"

--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -2,6 +2,8 @@ FROM debian:buster
 
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
+ARG LINSTOR_VERSION
+
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates
 RUN apt-get install -y gnupg2 && \
@@ -9,10 +11,10 @@ RUN apt-get install -y gnupg2 && \
 	 echo "deb http://packages.linbit.com/piraeus buster drbd-9.0" > /etc/apt/sources.list.d/linbit.list && \
 	 apt-get update && \
 	 apt-get install -y default-jre-headless && \
-	 apt-get install -y udev linstor-controller linstor-satellite linstor-client \
-	 drbd-utils wget xfsprogs jq procps nvme-cli \
+	 apt-get install -y udev drbd-utils wget xfsprogs jq procps nvme-cli \
 	 net-tools iputils-ping iproute2 dnsutils netcat sysstat curl \
 	 util-linux && \
+	 apt-get install -y linstor-controller=$LINSTOR_VERSION linstor-satellite=$LINSTOR_VERSION linstor-common=$LINSTOR_VERSION  linstor-client && \
 	 apt-get clean
 # remove jre-headless with linstor 0.9.13
 

--- a/dockerfiles/piraeus-server/Makefile
+++ b/dockerfiles/piraeus-server/Makefile
@@ -2,7 +2,6 @@ PROJECT ?= piraeus-server
 REGISTRY ?= piraeusdatastore
 K8S_AWAIT_ELECTION_VERSION ?= v0.1.0
 ARCH ?= amd64
-TAG ?= latest
 NOCACHE ?= false
 
 help:
@@ -12,14 +11,19 @@ all: update upload
 
 .PHONY: update
 update:
-	docker build --build-arg K8S_AWAIT_ELECTION_VERSION=$(K8S_AWAIT_ELECTION_VERSION) --build-arg ARCH=$(ARCH) --no-cache=$(NOCACHE) -t $(PROJECT):$(TAG) .
-	docker tag $(PROJECT):$(TAG) $(PROJECT):latest
+	. ./VERSION.env ; \
+	docker build --build-arg LINSTOR_VERSION=$$LINSTOR_VERSION --build-arg K8S_AWAIT_ELECTION_VERSION=$(K8S_AWAIT_ELECTION_VERSION) --build-arg ARCH=$(ARCH) --no-cache=$(NOCACHE) -t $(PROJECT):v$$LINSTOR_VERSION . ; \
+	docker tag $(PROJECT):v$$LINSTOR_VERSION $(PROJECT):v$$SHORT_VERSION ; \
+	docker tag $(PROJECT):v$$LINSTOR_VERSION $(PROJECT):latest ; \
 
 .PHONY: upload
 upload:
+	. ./VERSION.env ; \
 	for r in $(REGISTRY); do \
-		docker tag $(PROJECT):$(TAG) $$r/$(PROJECT):$(TAG) ; \
-		docker tag $(PROJECT):$(TAG) $$r/$(PROJECT):latest ; \
-		docker push $$r/$(PROJECT):$(TAG) ; \
+		docker tag $(PROJECT):v$$LINSTOR_VERSION $$r/$(PROJECT):v$$LINSTOR_VERSION ; \
+		docker tag $(PROJECT):v$$SHORT_VERSION $$r/$(PROJECT):v$$SHORT_VERSION ; \
+		docker tag $(PROJECT):latest $$r/$(PROJECT):latest ; \
+		docker push $$r/$(PROJECT):v$$LINSTOR_VERSION ; \
+		docker push $$r/$(PROJECT):v$$SHORT_VERSION ; \
 		docker push $$r/$(PROJECT):latest ; \
 	done

--- a/dockerfiles/piraeus-server/VERSION.env
+++ b/dockerfiles/piraeus-server/VERSION.env
@@ -1,0 +1,2 @@
+LINSTOR_VERSION=1.8.0-1
+SHORT_VERSION="$(echo "${LINSTOR_VERSION}" | grep -oE '^[^-]+')"


### PR DESCRIPTION
Add github workflow to push new piraeus-server images to:
* quay.io/piraeusdatastore
* docker.io/piraeusdatastore

To fix the version used, linstor components are now pinned to a specific
version. That version is also used as image tag.