### PR TITLE
This pull request is to configure lvm.conf in debian piraeus-server c…

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -27,6 +27,7 @@ COPY preferences /etc/apt/preferences
 RUN echo 'deb http://deb.debian.org/debian/ bullseye main contrib' >> /etc/apt/sources.list && \
 	apt-get update && apt-get install -y -t testing lvm2 && apt-get remove -y udev && apt-get clean
 RUN sed -i 's/udev_rules.*=.*/udev_rules=0/ ; s/udev_sync.*=.*/udev_sync=0/ ; s/obtain_device_list_from_udev.*=.*/obtain_device_list_from_udev=0/' /etc/lvm/lvm.conf
+RUN sed -i '/^devices {/a global_filter = [ "r|^/dev/drbd|" ]' /etc/lvm/lvm.conf
 
 # get zfsutils from testing
 RUN apt-get install -y -t testing zfsutils-linux && apt-get clean


### PR DESCRIPTION
…ontainer to block linstor-satelite reading /dev/drbd.*, which could be secondary state during device creation.

fixes #60

Signed-off-by: Tatsuya Naganawa <tatsuyan201101@gmail.com>