### PR TITLE
piraeus-server: use k8s-await-election v0.2.3

### DIFF
--- a/dockerfiles/piraeus-server/Makefile
+++ b/dockerfiles/piraeus-server/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= piraeus-server
 REGISTRY ?= piraeusdatastore
-K8S_AWAIT_ELECTION_VERSION ?= v0.2.2
+K8S_AWAIT_ELECTION_VERSION ?= v0.2.3
 ARCH ?= amd64
 NOCACHE ?= false
 


### PR DESCRIPTION
This version of k8s-await-election can set the "nodeName" attribute
on created endpoint resources. This enables Kubernetes "hairpin mode",
which is required for a pod to access it's own service.

This allows "linstor ..." commands from the controller container to succeed.
Previously they would never receive a response from the controller.