### PR TITLE
Ensure LINSTOR components log to files

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get install -y gnupg2 && \
 # Log directory need to be group writable. OpenShift assigns random UID and GID, without extra RBAC changes we can only influence the GID.
 RUN mkdir /var/log/linstor-controller && \
 	 chown 0:1000 /var/log/linstor-controller && \
-	 chmod -R 0775 /var/log/linstor-controller
+	 chmod -R 0775 /var/log/linstor-controller && \
+	 # Ensure we log to files in containers, otherwise SOS reports won't show any logs at all
+	 sed -i 's#<!-- <appender-ref ref="FILE" /> -->#<appender-ref ref="FILE" />#' /usr/share/linstor-server/lib/conf/logback.xml
 
 # satellite
 # needs a newer lvm, debian bug #932433


### PR DESCRIPTION
Enable logging to files for LINSTOR controller and satellite. The default
(only logging to stdout) meant that sos-reports would not contain any logs.

The default file backend that is configured but not enabled uses log rotation
(keep up to 10 log artifacts, each limited to 2MB), which should be a good
default for most environments.

See https://github.com/piraeusdatastore/piraeus-operator/issues/166