### PR TITLE
Implement multi-arch build for piraeus-client

### DIFF
--- a/.github/workflows/build-piraeus-client.yaml
+++ b/.github/workflows/build-piraeus-client.yaml
@@ -11,11 +11,36 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: build images
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
         run: |
+          DOCKERHUB_IMAGAE=docker.io/${{ secrets.DOCKERHUB_USERNAME }}/piraeus-client
+          QUAYIO_IMAGE=quay.io/${{ secrets.QUAYIO_USERNAME }}/piraeus-client
+        
           cd dockerfiles/piraeus-client
-          make update
+          . ./VERSION.env
+
+          TAGS="${DOCKERHUB_IMAGAE}:${LINSTOR_CLIENT_VERSION},${DOCKERHUB_IMAGAE}:${SHORT_VERSION}",${DOCKERHUB_IMAGAE}:latest,${QUAYIO_IMAGE}:${LINSTOR_CLIENT_VERSION},${QUAYIO_IMAGE}:${SHORT_VERSION}",${QUAYIO_IMAGE}:latest"
+
+          # Set output parameters.
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=docker_image::${DOCKERHUB_IMAGAE}
+          echo ::set-output name=quay_image::${QUAYIO_IMAGE}
+          echo ::set-output name=linstor_client_version::${LINSTOR_CLIENT_VERSION}
+          echo ::set-output name=python_linstor_version::${PYTHON_LINSTOR_VERSION}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
       - name: login to registry
         env:
           QUAYIO_USERNAME: ${{ secrets.QUAYIO_USERNAME }}
@@ -25,7 +50,15 @@ jobs:
         run: |
           docker login --username=${QUAYIO_USERNAME} --password-stdin quay.io <<< "${QUAYIO_PASSWORD}"
           docker login --username=${DOCKERHUB_USERNAME} --password-stdin docker.io <<< "${DOCKERHUB_PASSWORD}"
-      - name: push images
-        run: |
-          cd dockerfiles/piraeus-client
-          make upload REGISTRY="quay.io/piraeusdatastore docker.io/piraeusdatastore"
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            LINSTOR_CLIENT_VERSION=${{ steps.prep.outputs.linstor_client_version }}
+            PYTHON_LINSTOR_VERSION=${{ steps.prep.outputs.python_linstor_version }}
+          context: dockerfiles/piraeus-client
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
Closes #74

I didn't remove the Makefile with this PR in case that's used elsewhere. If it isn't we should be able to drop it.

