### PR TITLE
get GOARCH from docker, not from debian

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -42,10 +42,10 @@ EXPOSE 3366/tcp 3367/tcp
 
 COPY entry.sh /usr/bin/piraeus-entry.sh
 
-ARG ARCH
 ARG K8S_AWAIT_ELECTION_VERSION
+ARG TARGETARCH
 
-RUN wget https://github.com/LINBIT/k8s-await-election/releases/download/${K8S_AWAIT_ELECTION_VERSION}/k8s-await-election-${K8S_AWAIT_ELECTION_VERSION}-linux-$(dpkg --print-architecture).tar.gz -O - | tar -xvz -C /usr/bin/
+RUN wget https://github.com/LINBIT/k8s-await-election/releases/download/${K8S_AWAIT_ELECTION_VERSION}/k8s-await-election-${K8S_AWAIT_ELECTION_VERSION}-linux-${TARGETARCH}.tar.gz -O - | tar -xvz -C /usr/bin/
 
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]


### PR DESCRIPTION
GOARCH!=$(dpkg --get-architecture) for at least ppc64le

see https://github.com/piraeusdatastore/piraeus/pull/85#discussion_r692145200