### PR TITLE
enable multi-arch build for -reactor and -injector

### DIFF
--- a/.github/workflows/build-drbd-reactor.yaml
+++ b/.github/workflows/build-drbd-reactor.yaml
@@ -7,16 +7,49 @@ on:
     paths:
       - dockerfiles/drbd-reactor/*
       - .github/workflows/build-drbd-reactor.yaml
+  pull_request:
+    paths:
+      - dockerfiles/drbd-reactor/*
+      - .github/workflows/build-drbd-reactor.yaml
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: build images
+      - name: Prepare
+        id: prep
         run: |
+          DOCKERHUB_IMAGE=docker.io/piraeusdatastore/drbd-reactor
+          QUAYIO_IMAGE=quay.io/piraeusdatastore/drbd-reactor
+
           cd dockerfiles/drbd-reactor
-          make update
+          . ./VERSION.env
+
+          DOCKERHUB_TAG_FULL="${DOCKERHUB_IMAGE}:v${DRBD_REACTOR_VERSION}"
+          DOCKERHUB_TAG_SHORT="${DOCKERHUB_IMAGE}:v${SHORT_VERSION}"
+          DOCKERHUB_TAG_LATEST="${DOCKERHUB_IMAGE}:latest"
+          QUAYIO_TAG_FULL="${QUAYIO_IMAGE}:v${DRBD_REACTOR_VERSION}"
+          QUAYIO_TAG_SHORT="${QUAYIO_IMAGE}:v${SHORT_VERSION}"
+          QUAYIO_TAG_LATEST="${QUAYIO_IMAGE}:latest"
+
+          TAGS="$DOCKERHUB_TAG_FULL","$DOCKERHUB_TAG_SHORT","$DOCKERHUB_TAG_LATEST","$QUAYIO_TAG_FULL","$QUAYIO_TAG_SHORT","$QUAYIO_TAG_LATEST"
+
+          # Set output parameters.
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=docker_image::${DOCKERHUB_IMAGE}
+          echo ::set-output name=quay_image::${QUAYIO_IMAGE}
+          echo ::set-output name=drbd_reactor_version::${DRBD_REACTOR_VERSION}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
       - name: login to registry
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           QUAYIO_USERNAME: ${{ secrets.QUAYIO_USERNAME }}
           QUAYIO_PASSWORD: ${{ secrets.QUAYIO_PASSWORD }}
@@ -25,7 +58,14 @@ jobs:
         run: |
           docker login --username=${QUAYIO_USERNAME} --password-stdin quay.io <<< "${QUAYIO_PASSWORD}"
           docker login --username=${DOCKERHUB_USERNAME} --password-stdin docker.io <<< "${DOCKERHUB_PASSWORD}"
-      - name: push images
-        run: |
-          cd dockerfiles/drbd-reactor
-          make upload REGISTRY="quay.io/piraeusdatastore docker.io/piraeusdatastore"
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            DRBD_REACTOR_VERSION=${{ steps.prep.outputs.drbd_reactor_version }}
+          context: dockerfiles/drbd-reactor
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/build-injector.yaml
+++ b/.github/workflows/build-injector.yaml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: build images
-        run: |
-          cd dockerfiles/drbd-driver-loader
-          make update
       - name: login to registry
         env:
           QUAYIO_USERNAME: ${{ secrets.QUAYIO_USERNAME }}

--- a/dockerfiles/drbd-driver-loader/Makefile
+++ b/dockerfiles/drbd-driver-loader/Makefile
@@ -3,6 +3,7 @@ DF = Dockerfile.centos7 Dockerfile.centos8 Dockerfile.bionic Dockerfile.focal
 DEFAULT_CENTOS = Dockerfile.centos7
 REGISTRY ?= piraeusdatastore
 NOCACHE ?= false
+PLATFORMS = linux/amd64,linux/arm64
 
 help:
 	@echo "Useful targets: 'update', 'upload'"
@@ -25,11 +26,9 @@ upload:
 	for r in $(REGISTRY); do \
 		for f in $(DF); do \
 			pd=$(PROJECT)-$$(echo $$f | sed 's/^Dockerfile\.//'); \
-			docker tag $$pd:v$$DRBD_VERSION $$r/$$pd:v$$DRBD_VERSION ; \
-			docker tag $$pd:v$$SHORT_VERSION $$r/$$pd:v$$SHORT_VERSION ; \
-			docker tag $$pd:latest $$r/$$pd:latest ; \
-			docker push $$r/$$pd:v$$DRBD_VERSION ; \
-			docker push $$r/$$pd:v$$SHORT_VERSION ; \
-			docker push $$r/$$pd:latest ; \
+			docker buildx build --push --build-arg DRBD_VERSION=$$DRBD_VERSION --no-cache=$(NOCACHE) --platform=$(PLATFORMS) -f $$f \
+				--tag $$r/$$pd:v$$DRBD_VERSION \
+				--tag $$r/$$pd:v$$SHORT_VERSION \
+				--tag $$r/$$pd:latest . ; \
 		done; \
 	done


### PR DESCRIPTION
See #74

I changed the `Makefile`s to build for the local architecture on `make update` and build for all specified architectures on `make upload`.