### PR TITLE
Autoimport PEM certificates

### DIFF
--- a/dockerfiles/piraeus-server/entry.sh
+++ b/dockerfiles/piraeus-server/entry.sh
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+try_import_key() {
+  indir=$1
+  [ -d "$indir" ] || return 0
+  destkeystore=$2
+  destcrtstore=$3
+  tmpfile=$(mktemp)
+
+  openssl pkcs12 -export -in "${indir}/tls.crt" -inkey "${indir}/tls.key" -out "$tmpfile" -name linstor -passin 'pass:linstor' -passout 'pass:linstor'
+  keytool -importkeystore -srcstorepass linstor -deststorepass linstor -keypass linstor -srckeystore "$tmpfile" -destkeystore "$destkeystore"
+  keytool -importcert -noprompt -deststorepass linstor -keypass linstor -file "${indir}/ca.crt" -alias ca -destkeystore "$destcrtstore"
+  rm -f "$tmpfile"
+}
+
+try_import_key /etc/linstor/ssl-pem /etc/linstor/ssl/keystore.jks /etc/linstor/ssl/certificates.jks
+try_import_key /etc/linstor/https-pem /etc/linstor/https/keystore.jks /etc/linstor/https/truststore.jks
+
 [ -x /usr/bin/pre-start.sh ] && /usr/bin/pre-start.sh
 
 case $1 in


### PR DESCRIPTION
Automatically import PEM-certificates into Java keystore.

As part of https://github.com/piraeusdatastore/piraeus-operator/pull/262