### PR TITLE
ensure kmod tools are installed on centos/alma

### DIFF
--- a/dockerfiles/drbd-driver-loader/Dockerfile.almalinux8
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.almalinux8
@@ -4,7 +4,7 @@ MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 ARG DRBD_VERSION
 
 RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical && \
-	yum install -y wget gcc make patch curl elfutils-libelf-devel && yum clean all -y
+	yum install -y wget gcc make patch curl elfutils-libelf-devel kmod && yum clean all -y
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.centos7
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.centos7
@@ -4,7 +4,7 @@ MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 ARG DRBD_VERSION
 
 RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical && \
-	yum install -y wget gcc make patch curl ca-certificates && yum clean all -y
+	yum install -y wget gcc make patch curl ca-certificates kmod && yum clean all -y
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh


### PR DESCRIPTION
AlmaLinux no longer includes insmod in the base image, but it is needed
for the drbd loader to work. So we have to make sure it is installed.

The dependency was also added to the centos7 image, for completeness.