### PR TITLE
Dockerfiles: fix distro name

### DIFF
--- a/dockerfiles/drbd-reactor/Dockerfile
+++ b/dockerfiles/drbd-reactor/Dockerfile
@@ -1,12 +1,14 @@
-FROM debian:bullseye
+ARG DISTRO=bullseye
+FROM debian:$DISTRO
 
 ARG DRBD_REACTOR_VERSION
+ARG DISTRO
 
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates
 RUN apt-get install -y gnupg2 && \
 	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | apt-key add - && \
-	 echo "deb http://packages.linbit.com/public debian-bullseye misc" > /etc/apt/sources.list.d/linbit.list && \
+	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
 	 apt-get update && \
 	 apt-get install -y drbd-utils drbd-reactor=$DRBD_REACTOR_VERSION && \
 	 apt-get clean

--- a/dockerfiles/piraeus-client/Dockerfile
+++ b/dockerfiles/piraeus-client/Dockerfile
@@ -1,15 +1,17 @@
-FROM debian:bullseye
+ARG DISTRO=bullseye
+FROM debian:$DISTRO
 
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 ARG LINSTOR_CLIENT_VERSION
 ARG PYTHON_LINSTOR_VERSION
+ARG DISTRO
 
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates
 RUN apt-get install -y gnupg2 && \
     wget -O- https://packages.linbit.com/package-signing-pubkey.asc | apt-key add - && \
-    echo "deb http://packages.linbit.com/public debian-bullseye misc" > /etc/apt/sources.list.d/linbit.list && \
+    echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
     apt-get update && \
     apt-get install -y linstor-client=$LINSTOR_CLIENT_VERSION python-linstor=$PYTHON_LINSTOR_VERSION && \
     apt-get autoremove -y gnupg2 && apt-get clean

--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -1,8 +1,10 @@
-FROM debian:bullseye
+ARG DISTRO=bullseye
+FROM debian:$DISTRO
 
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 ARG LINSTOR_VERSION
+ARG DISTRO
 
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates && apt-get clean
@@ -10,8 +12,8 @@ RUN apt-get install -y gnupg2 && \
 	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | apt-key add - && \
 	# Enable contrib repos for zfsutils \
 	 sed -r -i 's/^deb(.*)$/deb\1 contrib/' /etc/apt/sources.list && \
-	 echo "deb http://packages.linbit.com/public debian-bullseye misc" > /etc/apt/sources.list.d/linbit.list && \
-	 echo "deb http://packages.linbit.com/public/staging debian-bullseye misc" >> /etc/apt/sources.list.d/linbit.list && \
+	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
+	 echo "deb http://packages.linbit.com/public/staging" $DISTRO "misc" >> /etc/apt/sources.list.d/linbit.list && \
 	 apt-get update && \
 	# Install useful utilities and general dependencies
 	 apt-get install -y udev drbd-utils jq net-tools iputils-ping iproute2 dnsutils netcat sysstat curl util-linux && \


### PR DESCRIPTION
The distro names used reflected a wrong naming on the LINBIT public repo
side of things. This got fixed, also fix them here.

While at it make it a bit more comfortable to switch distros by
introducing an ARG.