### PR TITLE
docker: remove make file bashism

### DIFF
--- a/.github/workflows/build-piraeus-server.yaml
+++ b/.github/workflows/build-piraeus-server.yaml
@@ -25,11 +25,11 @@ jobs:
           cd dockerfiles/piraeus-server
           . ./VERSION.env
 
-          DOCKERHUB_TAG_FULL="${DOCKERHUB_IMAGE}:v${LINSTOR_VERSION//'~'/-}"
-          DOCKERHUB_TAG_SHORT="${DOCKERHUB_IMAGE}:v${SHORT_VERSION//'~'/-}"
+          DOCKERHUB_TAG_FULL="${DOCKERHUB_IMAGE}:v$(echo -n $LINSTOR_VERSION | tr '~' -)"
+          DOCKERHUB_TAG_SHORT="${DOCKERHUB_IMAGE}:v$(echo -n $SHORT_VERSION | tr '~' -)"
           DOCKERHUB_TAG_LATEST="${DOCKERHUB_IMAGE}:latest"
-          QUAYIO_TAG_FULL="${QUAYIO_IMAGE}:v${LINSTOR_VERSION//'~'/-}"
-          QUAYIO_TAG_SHORT="${QUAYIO_IMAGE}:v${SHORT_VERSION//'~'/-}"
+          QUAYIO_TAG_FULL="${QUAYIO_IMAGE}:v$(echo -n $LINSTOR_VERSION | tr '~' -)"
+          QUAYIO_TAG_SHORT="${QUAYIO_IMAGE}:v$(echo -n $SHORT_VERSION | tr '~' -)"
           QUAYIO_TAG_LATEST="${QUAYIO_IMAGE}:latest"
 
           TAGS="$DOCKERHUB_TAG_FULL","$DOCKERHUB_TAG_SHORT","$DOCKERHUB_TAG_LATEST","$QUAYIO_TAG_FULL","$QUAYIO_TAG_SHORT","$QUAYIO_TAG_LATEST"

--- a/dockerfiles/piraeus-server/Makefile
+++ b/dockerfiles/piraeus-server/Makefile
@@ -15,8 +15,8 @@ update:
 		docker buildx build $(_EXTRA_ARGS) --build-arg LINSTOR_VERSION=$$LINSTOR_VERSION \
 			--build-arg K8S_AWAIT_ELECTION_VERSION=$$K8S_AWAIT_ELECTION_VERSION \
 			--no-cache=$(NOCACHE) --platform=$(PLATFORMS) \
-			--tag $$r/$(PROJECT):v$${LINSTOR_VERSION//'~'/-} \
-			--tag $$r/$(PROJECT):v$${SHORT_VERSION//'~'/-} \
+			--tag $$r/$(PROJECT):v$$(echo -n $$LINSTOR_VERSION | tr '~' -) \
+			--tag $$r/$(PROJECT):v$$(echo -n $$SHORT_VERSION | tr '~' -) \
 			--tag $$r/$(PROJECT):latest . ;\
 	done
 


### PR DESCRIPTION
6c7d1fd introduced some dependencies on bash variable expansion
in the makefile. This is generally a bad idea, as it will break on
any system that doesn't use bash as /bin/sh.

This commit replaces the bash variable expansion with a simple shell pipeline.

Fixes #103 