### PR TITLE
Dockerfiles: stop using apt-key

### DIFF
--- a/dockerfiles/drbd-reactor/Dockerfile
+++ b/dockerfiles/drbd-reactor/Dockerfile
@@ -7,7 +7,7 @@ ARG DISTRO
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates
 RUN apt-get install -y gnupg2 && \
-	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | apt-key add - && \
+	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
 	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
 	 apt-get update && \
 	 apt-get install -y drbd-utils drbd-reactor=$DRBD_REACTOR_VERSION && \

--- a/dockerfiles/piraeus-client/Dockerfile
+++ b/dockerfiles/piraeus-client/Dockerfile
@@ -10,7 +10,7 @@ ARG DISTRO
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates
 RUN apt-get install -y gnupg2 && \
-    wget -O- https://packages.linbit.com/package-signing-pubkey.asc | apt-key add - && \
+    wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
     echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
     apt-get update && \
     apt-get install -y linstor-client=$LINSTOR_CLIENT_VERSION python-linstor=$PYTHON_LINSTOR_VERSION && \

--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -9,7 +9,7 @@ ARG DISTRO
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
 RUN apt-get update && apt-get install -y wget ca-certificates && apt-get clean
 RUN apt-get install -y gnupg2 && \
-	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | apt-key add - && \
+	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
 	# Enable contrib repos for zfsutils \
 	 sed -r -i 's/^deb(.*)$/deb\1 contrib/' /etc/apt/sources.list && \
 	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \


### PR DESCRIPTION
apt-key is deprecated and current stable is the last one supporting it.
Switch to /etc/apt/tusted.gpg.d/

Signed-off-by: Roland Kammerer <roland.kammerer@linbit.com>