### PR TITLE
docker: disable LVM backup

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir /var/log/linstor-controller && \
 	 sed -i 's#<!-- <appender-ref ref="FILE" /> -->#<appender-ref ref="FILE" />#' /usr/share/linstor-server/lib/conf/logback.xml
 
 
-RUN lvmconfig --type current --mergedconfig --config 'activation { udev_rules = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
+RUN lvmconfig --type current --mergedconfig --config 'activation { udev_rules = 0 } backup { backup = 0 archive = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
 
 # controller
 EXPOSE 3376/tcp 3377/tcp 3370/tcp 3371/tcp


### PR DESCRIPTION
By default, LVM tools will create a "metadata backup" every time a pool
is modified. Since the backup location only exists while the container
exists, this wasn't very useful in the container context.

In the interest of making our images ready to be read-only, disable the
creation of LVM backups.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>