### PR TITLE
drbd-loader: add elfutils to focal

### DIFF
--- a/dockerfiles/drbd-driver-loader/Dockerfile.focal
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.focal
@@ -3,7 +3,7 @@ MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 ARG DRBD_VERSION
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch curl && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh


### PR DESCRIPTION
Ubuntu Focal uses the Jammy kernel for it's HWE kernel. To compile against the
newer kernel, you need elfutils installed.

Closes #118 