### PR TITLE
add missing libelf dependency to kernel-module-injector image

### DIFF
--- a/dockerfiles/drbd-driver-loader/Dockerfile
+++ b/dockerfiles/drbd-driver-loader/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:bionic
+
+ARG DRBD_VERSION=9.1.5
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch curl libelf-dev && apt-get clean
+
+RUN wget https://github.com/LINBIT/drbd/archive/refs/tags/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
+    wget https://github.com/LINBIT/drbd/raw/drbd-${DRBD_VERSION}/docker/entry.sh -O /entry.sh && chmod +x /entry.sh
+
+ENV LB_HOW compile
+ENTRYPOINT [ "/entry.sh" ]

--- a/dockerfiles/drbd-driver-loader/Dockerfile.bionic
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.bionic
@@ -3,7 +3,7 @@ MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 ARG DRBD_VERSION
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch curl && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch curl libelf-dev && apt-get clean
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.centos7
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.centos7
@@ -4,7 +4,7 @@ MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 ARG DRBD_VERSION
 
 RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical && \
-	yum install -y wget gcc make patch curl ca-certificates kmod && yum clean all -y
+	yum install -y wget gcc make patch curl ca-certificates elfutils-libelf-devel kmod && yum clean all -y
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.focal
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.focal
@@ -3,7 +3,7 @@ MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 ARG DRBD_VERSION
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl libelf-dev && apt-get clean
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.jammy
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.jammy
@@ -2,7 +2,7 @@ FROM ubuntu:jammy
 
 ARG DRBD_VERSION
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl libelf-dev && apt-get clean
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh


### PR DESCRIPTION
this PR fixes problem of compiling DRBD module on Rocky Linux 9
more details: https://github.com/deckhouse/deckhouse/issues/2268