### PR TITLE
piraeus-server: disable usage count for DRBD utils

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get install -y gnupg2 && \
 	  e2fsprogs \
 	# lsscsi: exos layer \
 	  lsscsi \
-    # lvm2: manage lvm storage pools \
-      lvm2 \
+	# lvm2: manage lvm storage pools \
+	  lvm2 \
 	# multipath-tools: exos layer \
 	  multipath-tools \
 	# nvme-cli: nvme layer

--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -58,6 +58,7 @@ RUN mkdir /var/log/linstor-controller && \
 
 
 RUN lvmconfig --type current --mergedconfig --config 'activation { udev_rules = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
+RUN echo 'global { usage-count no; }' > /etc/drbd.d/global_common.conf
 
 # controller
 EXPOSE 3376/tcp 3377/tcp 3370/tcp 3371/tcp


### PR DESCRIPTION
/var/lib/drbd/node_id is regenerated every time the container restarts, making the usage count not very useful.

Also includes a style fix in another commit