### PR TITLE
piraeus-server: start dmeventd on start-up

### DIFF
--- a/dockerfiles/piraeus-server/entry.sh
+++ b/dockerfiles/piraeus-server/entry.sh
@@ -21,6 +21,15 @@ try_import_key /etc/linstor/https-pem /etc/linstor/https/keystore.jks /etc/linst
 
 case $1 in
 	startSatellite)
+                # Some lvm daemons think it's a good idea to close all file descriptors starting at the soft FD cap.
+                # On newer systems such as RHEL9, this is around > 1_000_000_000, and may take some time.
+                # Instead, we just use the known-to-be-reasonable 1024*1024 we saw on RHEL8, and start the daemon
+                # here already.
+                SOFT_FILE_LIMIT="$(echo -e "1048576\n$(prlimit --noheadings --output SOFT --nofile)" | sort -n | head -1)"
+                if ! prlimit --nofile="$SOFT_FILE_LIMIT:" dmeventd; then
+                        echo "Could not start dmeventd. If LVM is not used, this can be ignored." >&2
+                fi
+
 		shift
 		/usr/share/linstor-server/bin/Satellite --logs=/var/log/linstor-satellite --config-directory=/etc/linstor --skip-hostname-check "$@"
 		;;


### PR DESCRIPTION
dmeventd will be started by lvm commands (i.e. lvcreate, lvremove, ..) if it does not already run. This is an issue if started in a context with a high soft file limit: dmeventd will try to close _all_ FDs after forking. The limit on Almalinux9 is higher than 1_000_000_000, which caused the initial command to wait for over 100 seconds, mostly leading to linstor commands timing out.

The workaround here is to start "dmeventd" before starting the satellite with a known reasonable file limit.

See also [0c6c6ec0d1d1d38320f66295d9f992ea8ee50815](https://github.com/LINBIT/linstor-server/commit/0c6c6ec0d1d1d38320f66295d9f992ea8ee50815) in the linstor-server project.