### PR TITLE
piraeus-server: fix prlimit parsing

### DIFF
--- a/dockerfiles/piraeus-server/entry.sh
+++ b/dockerfiles/piraeus-server/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 try_import_key() {
   indir=$1


### PR DESCRIPTION
The file limit parsing introduced in 2b2ec174bcd contains bash-isms. In order to stay true to upstream, we simply change our current script to bash as well.