### PR TITLE
Debian drbd-driver-loader support

### DIFF
--- a/dockerfiles/drbd-driver-loader/Dockerfile.bullseye
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.bullseye
@@ -1,0 +1,11 @@
+FROM debian:bullseye
+
+ARG DRBD_VERSION
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
+
+RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
+    wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh
+
+ENV LB_HOW compile
+ENTRYPOINT /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.buster
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.buster
@@ -1,0 +1,11 @@
+FROM debian:buster
+
+ARG DRBD_VERSION
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
+
+RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
+    wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh
+
+ENV LB_HOW compile
+ENTRYPOINT /entry.sh

--- a/dockerfiles/drbd-driver-loader/Makefile
+++ b/dockerfiles/drbd-driver-loader/Makefile
@@ -1,5 +1,5 @@
 PROJECT ?= drbd9
-DF = Dockerfile.centos7 Dockerfile.almalinux8 Dockerfile.almalinux9 Dockerfile.centos8 Dockerfile.bionic Dockerfile.focal Dockerfile.jammy Dockerfile.flatcar
+DF = Dockerfile.centos7 Dockerfile.almalinux8 Dockerfile.almalinux9 Dockerfile.centos8 Dockerfile.bionic Dockerfile.focal Dockerfile.jammy Dockerfile.flatcar Dockerfile.bullseye Dockerfile.buster
 REGISTRY ?= piraeusdatastore
 NOCACHE ?= false
 PLATFORMS ?= linux/amd64,linux/arm64


### PR DESCRIPTION
This adds images for bullseye and buster. I haven't tested this on buster, but I had tested the bullseye image yesterday and it worked fine.