### PR TITLE
docker,linstor: include migration script for k8s DB

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -79,5 +79,7 @@ RUN wget "https://github.com/LINBIT/losetup-container/releases/download/${LOSETU
 	 printf '#!/bin/sh\nLOSETUP_CONTAINER_ORIGINAL_LOSETUP=%s exec /usr/local/sbin/losetup-container "$@"\n' $(command -v losetup) > /usr/local/sbin/losetup && \
 	 chmod +x /usr/local/sbin/losetup
 
+RUN wget "https://dl.k8s.io/$(wget -O - https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" -O /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/dockerfiles/piraeus-server/entry.sh
+++ b/dockerfiles/piraeus-server/entry.sh
@@ -1,5 +1,31 @@
 #!/bin/bash
 
+set -e
+
+run_migration() {
+	if /usr/share/linstor-server/bin/linstor-config all-migrations-applied --logs=/var/log/linstor-controller --config-directory=/etc/linstor "$@" ; then
+		return 0
+	fi
+
+	VERSION=$(/usr/share/linstor-server/bin/linstor-config run-migration -v)
+
+	BACKUP_NAME=${BACKUP_NAME:-linstor-backup-for-$(hostname)}
+
+	if ! kubectl get secrets "${BACKUP_NAME}"; then
+		mkdir -p /run/migration
+		cd /run/migration
+		kubectl api-resources --api-group=internal.linstor.linbit.com -oname | xargs --no-run-if-empty kubectl get crds -oyaml > crds.yaml
+		for CRD in $(kubectl api-resources --api-group=internal.linstor.linbit.com -oname); do
+			kubectl get "${CRD}" -oyaml > "${CRD}.yaml"
+		done
+		tar -czvf backup.tar.gz -- *.yaml
+		kubectl create secret generic "${BACKUP_NAME}" --type piraeus.io/linstor-backup --from-file=backup.tar.gz
+		kubectl annotate secrets "${BACKUP_NAME}" "piraeus.io/linstor-version=${VERSION}"
+	fi
+
+	/usr/share/linstor-server/bin/linstor-config run-migration --config-directory=/etc/linstor "$@"
+}
+
 try_import_key() {
   indir=$1
   [ -d "$indir" ] || return 0
@@ -36,6 +62,10 @@ case $1 in
 	startController)
 		shift
 		/usr/share/linstor-server/bin/Controller --logs=/var/log/linstor-controller --config-directory=/etc/linstor "$@"
+		;;
+	runMigration)
+		shift
+		run_migration "$@"
 		;;
 	*) linstor "$@" ;;
 esac


### PR DESCRIPTION
We want to be able to run DB migrations for LINSTOR without having to start the full LINSTOR container. For this purpose, we add a new command to the entrypoint script, that:

* Checks the need for running migrations
* Creates a backup in the k8s API of the existing resources
* Runs the migrations

This command can be used as part of an init container in k8s.