### PR TITLE
docker,drbd: include kbuild tools in debian

### DIFF
--- a/dockerfiles/drbd-driver-loader/Dockerfile.bullseye
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.bullseye
@@ -2,7 +2,7 @@ FROM debian:bullseye
 
 ARG DRBD_VERSION
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl 'linux-kbuild-*' && apt-get clean
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.buster
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.buster
@@ -2,7 +2,7 @@ FROM debian:buster
 
 ARG DRBD_VERSION
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg wget make gcc patch elfutils curl 'linux-kbuild-*' && apt-get clean
 
 RUN wget https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz -O /drbd.tar.gz && \
     wget https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh -O /entry.sh && chmod +x /entry.sh


### PR DESCRIPTION
Debian separates some build tools out of the normal source directory. Without these tools, we cannot build a kernel module. The current "fix" was to mount /usr/lib from the host, but that predictably breaks other distros, as we create a franken-container that way.

The better fix is to install the linux-kbuild-* tools directly in the container.