### PR TITLE
docker: remove dmeventd dependency from linstor

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir /var/log/linstor-controller && \
 	 sed -i 's#<!-- <appender-ref ref="FILE" /> -->#<appender-ref ref="FILE" />#' /usr/share/linstor-server/lib/conf/logback.xml
 
 
-RUN lvmconfig --type current --mergedconfig --config 'activation { udev_rules = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
+RUN lvmconfig --type current --mergedconfig --config 'activation { udev_rules = 0 monitoring = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
 RUN echo 'global { usage-count no; }' > /etc/drbd.d/global_common.conf
 
 # controller

--- a/dockerfiles/piraeus-server/entry.sh
+++ b/dockerfiles/piraeus-server/entry.sh
@@ -47,21 +47,12 @@ try_import_key /etc/linstor/https-pem /etc/linstor/https/keystore.jks /etc/linst
 
 case $1 in
 	startSatellite)
-                # Some lvm daemons think it's a good idea to close all file descriptors starting at the soft FD cap.
-                # On newer systems such as RHEL9, this is around > 1_000_000_000, and may take some time.
-                # Instead, we just use the known-to-be-reasonable 1024*1024 we saw on RHEL8, and start the daemon
-                # here already.
-                SOFT_FILE_LIMIT="$(echo -e "1048576\n$(prlimit --noheadings --output SOFT --nofile)" | sort -n | head -1)"
-                if ! prlimit --nofile="$SOFT_FILE_LIMIT:" dmeventd; then
-                        echo "Could not start dmeventd. If LVM is not used, this can be ignored." >&2
-                fi
-
 		shift
-		/usr/share/linstor-server/bin/Satellite --logs=/var/log/linstor-satellite --config-directory=/etc/linstor --skip-hostname-check "$@"
+		exec /usr/share/linstor-server/bin/Satellite --logs=/var/log/linstor-satellite --config-directory=/etc/linstor --skip-hostname-check "$@"
 		;;
 	startController)
 		shift
-		/usr/share/linstor-server/bin/Controller --logs=/var/log/linstor-controller --config-directory=/etc/linstor "$@"
+		exec /usr/share/linstor-server/bin/Controller --logs=/var/log/linstor-controller --config-directory=/etc/linstor "$@"
 		;;
 	runMigration)
 		shift


### PR DESCRIPTION
When running in a container, we cannot assume to have access to dmeventd. Up to now, we manually started dmeventd to work around an issue when running the container on systemd with high rlimits. See 2b2ec174bcde for details.

However, there is no need to start dmeventd at all: it's primary use for automatic resizing VGs and LVs doesn't fit the use in containers anyways. So we can just disable "monitoring" of LVs, which in turn should prevent dmeventd from being started by some random lvcreate.

Also, use "exec" to start the linstor processes: that way they get to be PID 1 in the container and they receive any SIGINTs generated by the container runtime.