### PR TITLE
docker: use "tini" when starting tlshd

### DIFF
--- a/dockerfiles/ktls-utils/Dockerfile
+++ b/dockerfiles/ktls-utils/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get install -y gnupg2 && \
 	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
 	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
 	 apt-get update && \
-	 apt-get install -y ktls-utils=$KTLS_UTILS_VERSION && \
+	 apt-get install -y tini ktls-utils=$KTLS_UTILS_VERSION && \
 	 apt-get clean
 
 COPY --chmod=0600 tlshd.conf /etc/tlshd.conf
 
-CMD ["/usr/sbin/tlshd", "--stderr"]
+CMD ["/usr/bin/tini", "-g", "/usr/sbin/tlshd", "--", "--stderr"]


### PR DESCRIPTION
If a normal C program is started as PID 1, it will not have the default SIGTERM handler installed: instead the signal will be ignored. This means that during container shutdown, the container will run until forceful shutdown via SIGKILL.

To work around this issue, we use "tini", a tiny init system for containers to act as PID 1 in the container. This way, tlshd is started as PID 2 and gets the normal SIGTERM handling, as tini will forward these signals.

This is only needed for ktls-utils:
* drbd-reactor has custom SIGTERM handling.
* LINSTOR inherits SIGTERM handling via the JVM.