### PR TITLE
docker: switch base to debian 12

### DIFF
--- a/dockerfiles/drbd-reactor/Dockerfile
+++ b/dockerfiles/drbd-reactor/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bullseye
+ARG DISTRO=bookworm
 FROM debian:$DISTRO
 
 ARG DRBD_REACTOR_VERSION

--- a/dockerfiles/piraeus-client/Dockerfile
+++ b/dockerfiles/piraeus-client/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bullseye
+ARG DISTRO=bookworm
 FROM debian:$DISTRO
 
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>

--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bullseye
+ARG DISTRO=bookworm
 FROM debian:$DISTRO
 
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
@@ -11,12 +11,12 @@ RUN apt-get update && apt-get install -y wget ca-certificates && apt-get clean
 RUN apt-get install -y gnupg2 && \
 	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
 	# Enable contrib repos for zfsutils \
-	 sed -r -i 's/^deb(.*)$/deb\1 contrib/' /etc/apt/sources.list && \
+	 sed -i -r 's/^Components: (.*)$/Components: \1 contrib/' /etc/apt/sources.list.d/debian.sources && \
 	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
 	 echo "deb http://packages.linbit.com/public/staging" $DISTRO "misc" >> /etc/apt/sources.list.d/linbit.list && \
 	 apt-get update && \
 	# Install useful utilities and general dependencies
-	 apt-get install -y udev drbd-utils jq net-tools iputils-ping iproute2 dnsutils netcat sysstat curl util-linux && \
+	 apt-get install -y udev drbd-utils jq net-tools iputils-ping iproute2 dnsutils netcat-traditional sysstat curl util-linux && \
 	# Install dependencies for optional features \
 	 apt-get install -y \
 	# cryptsetup: luks layer


### PR DESCRIPTION
Some tools that interact with the kernel are not happy when using old tools on a new kernel. For example, turns out that resize2fs (the ext* resize tool) refuses to resize a mounted FS on a new kernel because the FS there reports some features it does not know about.

To fix, we use the latest debian stable release as our base image. Tools there should be new enough for the future.

See https://github.com/piraeusdatastore/piraeus-operator/issues/628