### PR TITLE
docker: fix udev sync in containers

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir /var/log/linstor-controller && \
 	 sed -i 's#<!-- <appender-ref ref="FILE" /> -->#<appender-ref ref="FILE" />#' /usr/share/linstor-server/lib/conf/logback.xml
 
 
-RUN lvmconfig --type current --mergedconfig --config 'activation { udev_rules = 0 monitoring = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
+RUN lvmconfig --type current --mergedconfig --config 'activation { udev_sync = 0 udev_rules = 0 monitoring = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] obtain_device_list_from_udev = 0}' > /etc/lvm/lvm.conf.new && mv /etc/lvm/lvm.conf.new /etc/lvm/lvm.conf
 RUN echo 'global { usage-count no; }' > /etc/drbd.d/global_common.conf
 
 # controller


### PR DESCRIPTION
Next operator release mounts /run/udev into the container because that is needed to get ZFS working. However, this had the side effect of breaking LVM.

LVM is by default checking for the existence of this directory to determine if it should wait for udev events. This is however broken inside containers, so the LVM commands all time out, breaking LINSTOR with weird errors all around.

To fix this, disable the "udev_sync", so LVM no longer waits on udev events.