### PR TITLE
docker: use common base image

### DIFF
--- a/dockerfiles/base.Dockerfile
+++ b/dockerfiles/base.Dockerfile
@@ -1,0 +1,14 @@
+ARG DISTRO=bookworm
+FROM debian:$DISTRO
+
+RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
+
+RUN --mount=type=cache,target=/var/cache,sharing=private \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=private \
+    --mount=type=tmpfs,target=/var/log \
+	 apt-get update && \
+	 apt-get install -y wget ca-certificates && \
+	 wget https://packages.linbit.com/public/linbit-keyring.deb -O /var/cache/linbit-keyring.deb && \
+	 dpkg -i /var/cache/linbit-keyring.deb && \
+	 . /etc/os-release && \
+	 echo "deb http://packages.linbit.com/public $VERSION_CODENAME misc" > /etc/apt/sources.list.d/linbit.list

--- a/dockerfiles/docker-bake.hcl
+++ b/dockerfiles/docker-bake.hcl
@@ -75,49 +75,56 @@ group "default" {
 }
 
 target "base" {
+  dockerfile = "base.Dockerfile"
+  args = {
+    DISTRO = DISTRO
+  }
+}
+
+target "common" {
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
 target "piraeus-server" {
-  inherits = ["base"]
+  inherits = ["common"]
   tags = tags("piraeus-server", VERSIONS["LINSTOR"])
   cache-from = cache-from("piraeus-server")
   cache-to = cache-to("piraeus-server")
   context = "piraeus-server"
+  contexts = { base = "target:base" }
   args = {
-    DISTRO                     = DISTRO
     LINSTOR_VERSION            = VERSIONS["LINSTOR"]
     K8S_AWAIT_ELECTION_VERSION = VERSIONS["K8S_AWAIT_ELECTION"]
   }
 }
 
 target "ktls-utils" {
-  inherits = ["base"]
+  inherits = ["common"]
   tags = tags("ktls-utils", VERSIONS["KTLS_UTILS"])
   cache-from = cache-from("ktls-utils")
   cache-to = cache-to("ktls-utils")
   context = "ktls-utils"
+  contexts = { base = "target:base" }
   args = {
-    DISTRO             = DISTRO
     KTLS_UTILS_VERSION = VERSIONS["KTLS_UTILS"]
   }
 }
 
 target "drbd-reactor" {
-  inherits = ["base"]
+  inherits = ["common"]
   tags = tags("drbd-reactor", VERSIONS["DRBD_REACTOR"])
   cache-from = cache-from("drbd-reactor")
   cache-to = cache-to("drbd-reactor")
   context = "drbd-reactor"
+  contexts = { base = "target:base" }
   args = {
-    DISTRO               = DISTRO
     DRBD_REACTOR_VERSION = VERSIONS["DRBD_REACTOR"]
   }
 }
 
 target "drbd-driver-loader" {
   name       = "drbd-driver-loader-${distro}-${escape(drbd_version)}"
-  inherits = ["base"]
+  inherits = ["common"]
   tags = tags("drbd9-${distro}", drbd_version)
   cache-from = cache-from("drbd9-${distro}")
   cache-to = cache-to("drbd9-${distro}")

--- a/dockerfiles/drbd-reactor/Dockerfile
+++ b/dockerfiles/drbd-reactor/Dockerfile
@@ -1,16 +1,10 @@
-ARG DISTRO=bookworm
-FROM debian:$DISTRO
+FROM base
 
-ARG DRBD_REACTOR_VERSION
-ARG DISTRO
-
-RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
-RUN apt-get update && apt-get install -y wget ca-certificates
-RUN apt-get install -y gnupg2 && \
-	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
-	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
+ARG DRBD_REACTOR_VERSION=*
+RUN --mount=type=cache,target=/var/cache,sharing=private \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=private \
+    --mount=type=tmpfs,target=/var/log \
 	 apt-get update && \
-	 apt-get install -y drbd-utils drbd-reactor=$DRBD_REACTOR_VERSION && \
-	 apt-get clean
+	 apt-get install -y drbd-utils drbd-reactor=$DRBD_REACTOR_VERSION
 
 CMD ["/usr/sbin/drbd-reactor"]

--- a/dockerfiles/ktls-utils/Dockerfile
+++ b/dockerfiles/ktls-utils/Dockerfile
@@ -1,17 +1,11 @@
-ARG DISTRO=bookworm
-FROM debian:$DISTRO
+FROM base
 
-ARG KTLS_UTILS_VERSION
-ARG DISTRO
-
-RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
-RUN apt-get update && apt-get install -y wget ca-certificates
-RUN apt-get install -y gnupg2 && \
-	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
-	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
+ARG KTLS_UTILS_VERSION=*
+RUN --mount=type=cache,target=/var/cache,sharing=private \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=private \
+    --mount=type=tmpfs,target=/var/log \
 	 apt-get update && \
-	 apt-get install -y tini ktls-utils=$KTLS_UTILS_VERSION && \
-	 apt-get clean
+	 apt-get install -y tini ktls-utils=$KTLS_UTILS_VERSION
 
 COPY --chmod=0600 tlshd.conf /etc/tlshd.conf
 

--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -1,20 +1,13 @@
-ARG DISTRO=bookworm
-FROM debian:$DISTRO
+FROM base
 
-MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
-
-ARG LINSTOR_VERSION
-ARG DISTRO
-
-RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
-RUN apt-get update && apt-get install -y wget ca-certificates && apt-get clean
-RUN apt-get install -y gnupg2 && \
-	 wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg && \
+ARG LINSTOR_VERSION=*
+RUN --mount=type=cache,target=/var/cache,sharing=private \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=private \
+    --mount=type=tmpfs,target=/var/log \
 	# Enable contrib repos for zfsutils \
+	 . /etc/os-release && \
 	 sed -i -r 's/^Components: (.*)$/Components: \1 contrib/' /etc/apt/sources.list.d/debian.sources && \
-	 echo "deb http://packages.linbit.com/public" $DISTRO "misc" > /etc/apt/sources.list.d/linbit.list && \
-	 echo "deb http://packages.linbit.com/public/staging" $DISTRO "misc" >> /etc/apt/sources.list.d/linbit.list && \
-	 echo "deb http://deb.debian.org/debian $DISTRO-backports contrib" > /etc/apt/sources.list.d/backports.list  && \
+	 echo "deb http://deb.debian.org/debian $VERSION_CODENAME-backports contrib" > /etc/apt/sources.list.d/backports.list && \
 	 apt-get update && \
 	# Install useful utilities and general dependencies
 	 apt-get install -y udev drbd-utils jq net-tools iputils-ping iproute2 dnsutils netcat-traditional sysstat curl util-linux && \
@@ -43,12 +36,11 @@ RUN apt-get install -y gnupg2 && \
 	# zstd: used with thin-send-recv to send snapshots to another LINSTOR cluster \
 	  zstd \
 	# zfsutils-linux: for zfs storage pools \
-	  zfsutils-linux/$DISTRO-backports \
+	  zfsutils-linux/$VERSION_CODENAME-backports \
 	 && \
 	# remove udev, no need for it in the container \
 	 apt-get remove -y udev && \
-	 apt-get install -y linstor-controller=$LINSTOR_VERSION linstor-satellite=$LINSTOR_VERSION linstor-common=$LINSTOR_VERSION  linstor-client && \
-	 apt-get clean
+	 apt-get install -y linstor-controller=$LINSTOR_VERSION linstor-satellite=$LINSTOR_VERSION linstor-common=$LINSTOR_VERSION linstor-client
 
 # Log directory need to be group writable. OpenShift assigns random UID and GID, without extra RBAC changes we can only influence the GID.
 RUN mkdir /var/log/linstor-controller && \


### PR DESCRIPTION
In order to configure the LINBIT repositories, we need to install the linbit-keyring package. This requires some set up as we need to fetch the package and then set up the repositories.

To make this nicer to work with, we use a single base docker image as the root of all builds.

While at it, also make use of proper tmpfs and cache mounts, so we do not add unnecessary files into the image layers.