### PR TITLE
docker: debian 13 drbd-loader

### DIFF
--- a/dockerfiles/docker-bake.hcl
+++ b/dockerfiles/docker-bake.hcl
@@ -142,6 +142,7 @@ target "drbd-driver-loader" {
       "noble",
       "bullseye",
       "bookworm",
+      "trixie",
     ]
   }
   args = {

--- a/dockerfiles/drbd-driver-loader/Dockerfile.trixie
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.trixie
@@ -1,0 +1,10 @@
+FROM debian:trixie
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
+
+ARG DRBD_VERSION
+ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz
+ADD --chmod=0755 https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh /entry.sh
+
+ENV LB_HOW compile
+ENTRYPOINT /entry.sh


### PR DESCRIPTION
I tested it by building it manually on debian 13, and it works well.

This is just a copy of the bullseye dockerfile with the codename changed.

Thank you for your work.