### PR TITLE
Bundle `spatch` in container to apply patches locally

### DIFF
--- a/dockerfiles/drbd-driver-loader/Dockerfile.almalinux8
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.almalinux8
@@ -2,11 +2,14 @@ FROM almalinux:8
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 RUN dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical && \
-	dnf install -y gcc make patch diffutils perl elfutils-libelf-devel kmod && dnf clean all -y
+    dnf install -y epel-release && \
+    dnf config-manager --set-enabled powertools && \
+    dnf install -y gcc make patch coccinelle diffutils perl elfutils-libelf-devel kmod && \
+    dnf clean all -y
 
 ARG DRBD_VERSION
 ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz
 ADD --chmod=0755 https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh /entry.sh
 
-ENV LB_HOW compile
-ENTRYPOINT /entry.sh
+ENV LB_HOW=compile
+ENTRYPOINT ["/entry.sh"]

--- a/dockerfiles/drbd-driver-loader/Dockerfile.almalinux8
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.almalinux8
@@ -2,14 +2,11 @@ FROM almalinux:8
 MAINTAINER Roland Kammerer <roland.kammerer@linbit.com>
 
 RUN dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical && \
-    dnf install -y epel-release && \
-    dnf config-manager --set-enabled powertools && \
-    dnf install -y gcc make patch coccinelle diffutils perl elfutils-libelf-devel kmod && \
-    dnf clean all -y
+	dnf install -y gcc make patch diffutils perl elfutils-libelf-devel kmod && dnf clean all -y
 
 ARG DRBD_VERSION
 ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz
 ADD --chmod=0755 https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh /entry.sh
 
-ENV LB_HOW=compile
-ENTRYPOINT ["/entry.sh"]
+ENV LB_HOW compile
+ENTRYPOINT /entry.sh

--- a/dockerfiles/drbd-driver-loader/Dockerfile.bookworm
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.bookworm
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch coccinelle diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
 
 ARG DRBD_VERSION
 ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz

--- a/dockerfiles/drbd-driver-loader/Dockerfile.bullseye
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.bullseye
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch coccinelle diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
 
 ARG DRBD_VERSION
 ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz

--- a/dockerfiles/drbd-driver-loader/Dockerfile.jammy
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.jammy
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      coccinelle \
       kmod \
       gnupg \
       make \

--- a/dockerfiles/drbd-driver-loader/Dockerfile.noble
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.noble
@@ -10,6 +10,7 @@ RUN apt-get update && \
       # Ubuntu has multiple kernel versions that may be using different gcc versions: use the dkms package to install them all
       $(apt-get install -s dkms | awk '/^Inst gcc/{print $2}') \
       patch \
+      coccinelle \
       diffutils \
       perl \
       elfutils \

--- a/dockerfiles/drbd-driver-loader/Dockerfile.trixie
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.trixie
@@ -1,6 +1,6 @@
 FROM debian:trixie
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get install -y kmod gnupg make gcc patch coccinelle diffutils perl elfutils curl 'linux-kbuild-*' && apt-get clean
 
 ARG DRBD_VERSION
 ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz


### PR DESCRIPTION
Private clouds often lack direct Internet access. If the `spatch` binary is missing and Spatch-as-a-Service is unavailable, `drbd-module-loader` cannot patch the DRBD sources and build `drbd.ko`.

This pull request adds a step to the Dockerfiles to install `spatch` (provided by the `coccinelle` package). The `coccinelle` package is available on Debian-based distributions and on AlmaLinux 8 via EPEL 8.