### PR TITLE
fix(piraeus-server): Use TARGETARCH for losetup-container download

### DIFF
--- a/dockerfiles/piraeus-server/Dockerfile
+++ b/dockerfiles/piraeus-server/Dockerfile
@@ -69,7 +69,9 @@ ARG TARGETARCH
 RUN wget https://github.com/LINBIT/k8s-await-election/releases/download/${K8S_AWAIT_ELECTION_VERSION}/k8s-await-election-${K8S_AWAIT_ELECTION_VERSION}-linux-${TARGETARCH}.tar.gz -O - | tar -xvz -C /usr/bin/
 
 ARG LOSETUP_CONTAINER_VERSION=v1.0.1
-RUN wget "https://github.com/LINBIT/losetup-container/releases/download/${LOSETUP_CONTAINER_VERSION}/losetup-container-$(uname -m)-unknown-linux-gnu.tar.gz" -O - | tar -xvz -C /usr/local/sbin && \
+# Map TARGETARCH to uname -m format for losetup-container download
+RUN ARCH=$(case ${TARGETARCH} in amd64) echo x86_64;; arm64) echo aarch64;; *) echo ${TARGETARCH};; esac) && \
+	 wget "https://github.com/LINBIT/losetup-container/releases/download/${LOSETUP_CONTAINER_VERSION}/losetup-container-${ARCH}-unknown-linux-gnu.tar.gz" -O - | tar -xvz -C /usr/local/sbin && \
 	 printf '#!/bin/sh\nLOSETUP_CONTAINER_ORIGINAL_LOSETUP=%s exec /usr/local/sbin/losetup-container "$@"\n' $(command -v losetup) > /usr/local/sbin/losetup && \
 	 chmod +x /usr/local/sbin/losetup
 


### PR DESCRIPTION
## Summary

Use `TARGETARCH` instead of `$(uname -m)` for downloading losetup-container binary, consistent with how `k8s-await-election` and `kubectl` are already downloaded in the same Dockerfile.

## Motivation

The Dockerfile already uses `${TARGETARCH}` for two other downloads:
- Line 69: `k8s-await-election-...-linux-${TARGETARCH}.tar.gz`
- Line 76: `.../bin/linux/${TARGETARCH}/kubectl`

Only `losetup-container` uses `$(uname -m)`. This change aligns all architecture-dependent downloads to use the same explicit mechanism.

## Changes

```dockerfile
# Before
RUN wget "...losetup-container-$(uname -m)-unknown-linux-gnu.tar.gz"

# After
RUN ARCH=$(case ${TARGETARCH} in amd64) echo x86_64;; arm64) echo aarch64;; *) echo ${TARGETARCH};; esac) && \
    wget "...losetup-container-${ARCH}-unknown-linux-gnu.tar.gz"
```