### PR TITLE
docker: ubuntu 26.04 (resolute) loader

### DIFF
--- a/dockerfiles/docker-bake.hcl
+++ b/dockerfiles/docker-bake.hcl
@@ -147,6 +147,7 @@ target "drbd-driver-loader" {
       "almalinux10",
       "jammy",
       "noble",
+      "resolute",
       "bullseye",
       "bookworm",
       "trixie",

--- a/dockerfiles/drbd-driver-loader/Dockerfile.noble
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.noble
@@ -15,7 +15,6 @@ RUN apt-get update && \
       perl \
       elfutils \
       libc-dev \
-      coccinelle \
       curl && \
     apt-get clean
 

--- a/dockerfiles/drbd-driver-loader/Dockerfile.resolute
+++ b/dockerfiles/drbd-driver-loader/Dockerfile.resolute
@@ -1,0 +1,26 @@
+FROM ubuntu:resolute
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
+      ca-certificates \
+      kmod \
+      gpg \
+      make \
+      # Ubuntu has multiple kernel versions that may be using different gcc versions: use the dkms package to install them all
+      $(apt-get install -s dkms | awk '/^Inst gcc/{print $2}') \
+      patch \
+      coccinelle \
+      diffutils \
+      perl \
+      elfutils \
+      libc-dev \
+      curl && \
+    apt-get clean
+
+ARG DRBD_VERSION
+ADD https://pkg.linbit.com/downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz /drbd.tar.gz
+ADD --chmod=0755 https://raw.githubusercontent.com/LINBIT/drbd/master/docker/entry.sh /entry.sh
+
+ENV LB_HOW compile
+ENTRYPOINT /entry.sh


### PR DESCRIPTION
Add a `drbd-driver-loader` image variant for Ubuntu 26.04 LTS ("Resolute Raccoon", released 2026-04-23). Mirrors `Dockerfile.noble`; only the base image changes from `ubuntu:noble` to `ubuntu:resolute`.

## Why

Ubuntu 26.04 ships kernel 7.0 built with gcc-15. That kernel's headers reference `-fmin-function-alignment=16`, a flag only recognised by gcc-14+. Without a 26.04-specific image, satellites running on 26.04 fall through to the `drbd9-noble` fallback, whose `ubuntu:noble` base carries gcc-13, and the on-node DRBD compile fails with:

```text
gcc: error: unrecognized command-line option '-fmin-function-alignment=16';
     did you mean '-flimit-function-alignment'?
```

`ubuntu:resolute` pulls gcc-15 via the existing `dkms` recommendation logic in `Dockerfile.noble`, so the same logic just works. Verified locally:

| DRBD | base | gcc | kernel headers | result |
|---|---|---|---|---|
| 9.2.16 | ubuntu:noble | 13 | 7.0.0-14 | fails on `-fmin-function-alignment` |
| 9.2.16 | ubuntu:resolute | 15 | 7.0.0-14 | fails on `sockaddr_unsized` (kernel API change, separate matter) |
| 9.3.1 | ubuntu:resolute | 15 | 7.0.0-14 | builds cleanly |
| 9.3.2 | ubuntu:resolute | 15 | 7.0.0-14 | builds cleanly |

Since `docker-bake.hcl` already pins `VERSIONS["DRBD"] = 9.3.1`, the new image will build cleanly out of the box.

Pairs with the matching match-rule update in piraeusdatastore/piraeus-operator (separate PR).

## Build verification

`docker buildx bake --set "*.platform=linux/amd64" --load drbd-driver-loader-resolute` succeeds locally on a checkout of this branch.

## Notes

The second commit (`docker(drbd-driver-loader): drop duplicate coccinelle from ubuntu noble`) is a tiny drive-by fix: `Dockerfile.noble` lists `coccinelle` twice — once added in 4ff165d ("docker: ubuntu 24.04 loader") and again in bb1f3fe ("Install coccinelle in Debian-based distributions"), which did not notice the existing entry. All other Debian-family loaders list it once. Functionally harmless (apt collapses duplicates), but bringing noble back in line with its siblings — happy to drop the commit if you'd prefer it as a separate PR.