### PR TITLE
docker: switch to debian:trixie base

### DIFF
--- a/dockerfiles/base.Dockerfile
+++ b/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bookworm
+ARG DISTRO=trixie
 FROM debian:$DISTRO
 
 RUN { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus

--- a/dockerfiles/docker-bake.hcl
+++ b/dockerfiles/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "DISTRO" {
-  default = "bookworm"
+  default = "trixie"
 }
 
 variable "GIT_COMMIT" {
@@ -20,13 +20,13 @@ variable VERSIONS {
     DRBD    = "9.3.2"
     # renovate: type=github-tags url=https://github.com depName=LINBIT/k8s-await-election
     K8S_AWAIT_ELECTION = "v0.4.2"
-    # renovate: type=deb url=https://packages.linbit.com/public?suite=bookworm&components=misc&binaryArch=amd64 depName=drbd-reactor
+    # renovate: type=deb url=https://packages.linbit.com/public?suite=trixie&components=misc&binaryArch=amd64 depName=drbd-reactor
     DRBD_REACTOR = "1.11.0-1"
-    # renovate: type=deb url=https://packages.linbit.com/public?suite=bookworm&components=misc&binaryArch=amd64 depName=ktls-utils
+    # renovate: type=deb url=https://packages.linbit.com/public?suite=trixie&components=misc&binaryArch=amd64 depName=ktls-utils
     KTLS_UTILS = "1.2.1-1"
-    # renovate: type=deb url=https://packages.linbit.com/public?suite=bookworm&components=misc&binaryArch=amd64 depName=linstor-common
+    # renovate: type=deb url=https://packages.linbit.com/public?suite=trixie&components=misc&binaryArch=amd64 depName=linstor-common
     LINSTOR = "1.33.3-1"
-    # renovate: type=deb url=https://packages.linbit.com/public?suite=bookworm&components=misc&binaryArch=amd64 depName=linstor-gui
+    # renovate: type=deb url=https://packages.linbit.com/public?suite=trixie&components=misc&binaryArch=amd64 depName=linstor-gui
     LINSTOR_GUI = "2.4.0-1"
   }
 }


### PR DESCRIPTION
New LINSTOR release no longer supports debian:bookworm, so switch to debian trixie.